### PR TITLE
Fix: Enter key to send message when nothing is selected in autocomplete

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/MainFragment.kt
@@ -773,12 +773,12 @@ class MainFragment : Fragment() {
         //setDropDownBackgroundResource(R.color.colorPrimary)
         setTokenizer(SpaceTokenizer())
         suggestionAdapter = EmoteSuggestionsArrayAdapter(binding.input.context) { count ->
-            binding.input.dropDownHeight = if (count > 2) {
+            dropDownHeight = if (count > 2) {
                 (binding.viewPager.measuredHeight / 1.3).roundToInt()
             } else {
                 ViewGroup.LayoutParams.WRAP_CONTENT
             }
-            binding.input.dropDownWidth = (binding.viewPager.measuredWidth * 0.6).roundToInt()
+            dropDownWidth = (binding.viewPager.measuredWidth * 0.6).roundToInt()
         }
         suggestionAdapter.setNotifyOnChange(false)
 
@@ -791,7 +791,7 @@ class MainFragment : Fragment() {
         setOnKeyListener { _, keyCode, _ ->
             when (keyCode) {
                 KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
-                    if (!isPopupShowing) sendMessage() else false
+                    if (!isItemSelected()) sendMessage() else false
                 }
                 else -> false
             }

--- a/app/src/main/kotlin/com/flxrs/dankchat/utils/CustomMultiAutoCompleteTextView.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/utils/CustomMultiAutoCompleteTextView.kt
@@ -3,6 +3,7 @@ package com.flxrs.dankchat.utils
 import android.content.Context
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.widget.AdapterView
 import androidx.appcompat.widget.AppCompatMultiAutoCompleteTextView
 import com.flxrs.dankchat.chat.suggestion.EmoteSuggestionsArrayAdapter
 
@@ -25,4 +26,6 @@ class CustomMultiAutoCompleteTextView : AppCompatMultiAutoCompleteTextView {
             setAdapter(null)
         }
     }
+
+    fun isItemSelected() = this.listSelection != AdapterView.INVALID_POSITION
 }


### PR DESCRIPTION
Old behaviour locked up entirely the enter key whenever the autocomplete popup was shown.
This new behaviour only locks up enter when autocomplete has no item selected.