### PR TITLE
Use high-res mod icon

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/service/api/dto/EmoteDtos.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/service/api/dto/EmoteDtos.kt
@@ -40,7 +40,7 @@ sealed class EmoteDtos {
 
         @Keep
         data class Room(
-            @field:Json(name = "mod_urls") val modBadgeUrls: Map<String, String?>
+            @field:Json(name = "mod_urls") val modBadgeUrls: Map<String, String?>?
         )
 
         @Keep

--- a/app/src/main/kotlin/com/flxrs/dankchat/service/api/dto/EmoteDtos.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/service/api/dto/EmoteDtos.kt
@@ -40,7 +40,7 @@ sealed class EmoteDtos {
 
         @Keep
         data class Room(
-            @field:Json(name = "moderator_badge") val moderatorBadgeUrl: String?
+            @field:Json(name = "mod_urls") val modBadgeUrls: Map<String, String?>
         )
 
         @Keep

--- a/app/src/main/kotlin/com/flxrs/dankchat/service/twitch/emote/EmoteManager.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/service/twitch/emote/EmoteManager.kt
@@ -114,7 +114,7 @@ class EmoteManager @Inject constructor(private val apiManager: ApiManager) {
             }
         }
         ffzEmotes[channel] = emotes
-        ffzResult.room.moderatorBadgeUrl?.let { ffzModBadges[channel] = "https:$it" }
+        ffzResult.room.modBadgeUrls?.let { ffzModBadges[channel] = "https:" + ( it["4"] ?: it["2"] ?: it["1"] ) }
     }
 
     suspend fun setFFZGlobalEmotes(ffzResult: EmoteDtos.FFZ.GlobalResult) = withContext(Dispatchers.Default) {


### PR DESCRIPTION
The FFZ api provides a field containing the mod icon with different scaling as opposed to the "moderator_badge" field only providing the lowest resolution icon. The String is null if an icon isn't provided at that scale.