### PR TITLE
Allow # prefix in new channel name

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -451,7 +451,7 @@ class MainFragment : Fragment() {
     }
 
     private fun addChannel(channel: String) {
-        val lowerCaseChannel = channel.lowercase(Locale.getDefault())
+        val lowerCaseChannel = channel.lowercase(Locale.getDefault()).removePrefix("#")
         val channels = mainViewModel.getChannels()
         if (!channels.contains(lowerCaseChannel)) {
             val oauth = dankChatPreferences.oAuthKey ?: ""


### PR DESCRIPTION
Enables entering a new channel name with a # prefix. Currently `#channel` will be opened which isn't a valid channel, this removes the prefix and opens `channel` instead.
Closes #135