### PR TITLE
Add setting to prioritize emote suggestions

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -714,7 +714,7 @@ class MainFragment : Fragment() {
                 scrollBackLengthKey -> mainViewModel.setScrollbackLength(ChatSettingsFragment.correctScrollbackLength(p.getInt(scrollBackLengthKey, 10)))
                 keepScreenOnKey -> keepScreenOn(p.getBoolean(key, true))
                 suggestionsKey -> binding.input.setSuggestionAdapter(p.getBoolean(key, true), suggestionAdapter)
-                preferEmotesSuggestionsKey -> mainViewModel.preferEmoteSuggestions.value = p.getBoolean(key, false)
+                preferEmotesSuggestionsKey -> mainViewModel.setPreferEmotesSuggestions(p.getBoolean(key, false))
             }
         }
         preferences.apply {
@@ -725,7 +725,7 @@ class MainFragment : Fragment() {
                 setRoomStateEnabled(getBoolean(roomStateKey, true))
                 setStreamInfoEnabled(getBoolean(streamInfoKey, true))
                 inputEnabled.value = getBoolean(inputKey, true)
-                preferEmoteSuggestions.value = getBoolean(preferEmotesSuggestionsKey, false)
+                setPreferEmotesSuggestions(getBoolean(preferEmotesSuggestionsKey, false))
                 binding.input.setSuggestionAdapter(getBoolean(suggestionsKey, true), suggestionAdapter)
 
                 setMentionEntries(getStringSet(customMentionsKey, emptySet()))

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -692,6 +692,7 @@ class MainFragment : Fragment() {
         val timestampFormatKey = getString(R.string.preference_timestamp_format_key)
         val loadSupibotKey = getString(R.string.preference_supibot_suggestions_key)
         val scrollBackLengthKey = getString(R.string.preference_scrollback_length_key)
+        val preferEmotesSuggestionsKey = getString(R.string.preference_prefer_emote_suggestions_key)
         dankChatPreferences = DankChatPreferenceStore(context)
         if (dankChatPreferences.isLoggedIn && dankChatPreferences.oAuthKey.isNullOrBlank()) {
             dankChatPreferences.clearLogin()
@@ -713,6 +714,7 @@ class MainFragment : Fragment() {
                 scrollBackLengthKey -> mainViewModel.setScrollbackLength(ChatSettingsFragment.correctScrollbackLength(p.getInt(scrollBackLengthKey, 10)))
                 keepScreenOnKey -> keepScreenOn(p.getBoolean(key, true))
                 suggestionsKey -> binding.input.setSuggestionAdapter(p.getBoolean(key, true), suggestionAdapter)
+                preferEmotesSuggestionsKey -> mainViewModel.preferEmoteSuggestions.value = p.getBoolean(key, false)
             }
         }
         preferences.apply {
@@ -723,6 +725,7 @@ class MainFragment : Fragment() {
                 setRoomStateEnabled(getBoolean(roomStateKey, true))
                 setStreamInfoEnabled(getBoolean(streamInfoKey, true))
                 inputEnabled.value = getBoolean(inputKey, true)
+                preferEmoteSuggestions.value = getBoolean(preferEmotesSuggestionsKey, false)
                 binding.input.setSuggestionAdapter(getBoolean(suggestionsKey, true), suggestionAdapter)
 
                 setMentionEntries(getStringSet(customMentionsKey, emptySet()))

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
@@ -82,6 +82,7 @@ class MainViewModel @Inject constructor(
     private val supibotCommandSuggestions = supibotCommands.mapLatest { commands ->
         commands.map { Suggestion.CommandSuggestion("$$it") }
     }
+    val preferEmoteSuggestions = MutableStateFlow(false)
 
     val events = eventChannel.receiveAsFlow()
 
@@ -144,7 +145,10 @@ class MainViewModel @Inject constructor(
 
     val suggestions: Flow<List<Suggestion>> =
         combine(emoteSuggestions, userSuggestions, supibotCommandSuggestions) { emoteSuggestions, userSuggestions, supibotCommandSuggestions ->
-            userSuggestions + supibotCommandSuggestions + emoteSuggestions
+            if (preferEmoteSuggestions.value)
+                    (emoteSuggestions + userSuggestions + supibotCommandSuggestions)
+            else
+                    (userSuggestions + emoteSuggestions + supibotCommandSuggestions)
         }
 
     val emoteItems: Flow<List<List<EmoteItem>>> = emotes.map { emotes ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,7 +193,7 @@
     <string name="preference_show_username_key" translatable="false">show_username_key</string>
     <string name="preference_visible_badges_title">Visible badges</string>
     <string name="preference_visible_badges_key" translatable="false">visible_badges_key</string>
-    <string name="preference_prefer_emote_suggestions_key translatable="false"">prefer_emote_suggestions_key</string>
+    <string name="preference_prefer_emote_suggestions_key" translatable="false">prefer_emote_suggestions_key</string>
     <string name="preference_prefer_emote_suggestions_title">Prefer emote suggestions</string>
     <string name="preference_prefer_emote_suggestions_summary">Prioritize emote suggestions over user suggestions</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,7 +193,7 @@
     <string name="preference_show_username_key" translatable="false">show_username_key</string>
     <string name="preference_visible_badges_title">Visible badges</string>
     <string name="preference_visible_badges_key" translatable="false">visible_badges_key</string>
-    <string name="preference_prefer_emote_suggestions_key">prefer_emote_suggestions_key</string>
+    <string name="preference_prefer_emote_suggestions_key translatable="false"">prefer_emote_suggestions_key</string>
     <string name="preference_prefer_emote_suggestions_title">Prefer emote suggestions</string>
     <string name="preference_prefer_emote_suggestions_summary">Prioritize emote suggestions over user suggestions</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,9 @@
     <string name="preference_show_username_key" translatable="false">show_username_key</string>
     <string name="preference_visible_badges_title">Visible badges</string>
     <string name="preference_visible_badges_key" translatable="false">visible_badges_key</string>
+    <string name="preference_prefer_emote_suggestions_key">prefer_emote_suggestions_key</string>
+    <string name="preference_prefer_emote_suggestions_title">Prefer emote suggestions</string>
+    <string name="preference_prefer_emote_suggestions_summary">Prioritize emote suggestions over user suggestions</string>
 
     <plurals name="viewers">
         <item quantity="one">Live with %d viewer</item>

--- a/app/src/main/res/xml/chat_settings.xml
+++ b/app/src/main/res/xml/chat_settings.xml
@@ -14,6 +14,13 @@
 
         <SwitchPreferenceCompat
             android:defaultValue="false"
+            android:key="@string/preference_prefer_emote_suggestions_key"
+            android:title="@string/preference_prefer_emote_suggestions_title"
+            android:summary="@string/preference_prefer_emote_suggestions_summary"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
             android:key="@string/preference_supibot_suggestions_key"
             android:title="@string/preference_supibot_suggestions_title"
             app:iconSpaceReserved="false" />


### PR DESCRIPTION
Adds a setting that chooses whether or not to prioritize emote suggestions over user suggestions.

Closes #43 