### PR TITLE
feat: add a "Paste" button to the image upload snackbar

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -528,7 +528,10 @@ class MainFragment : Fragment() {
             is ImageUploadState.Finished -> {
                 val clipboard = getSystemService(requireContext(), ClipboardManager::class.java)
                 clipboard?.setPrimaryClip(ClipData.newPlainText("nuuls image url", result.url))
-                showSnackbar(getString(R.string.snackbar_image_uploaded, result.url))
+                showSnackbar(
+                    message = getString(R.string.snackbar_image_uploaded, result.url),
+                    action = getString(R.string.snackbar_paste) to { insertText(result.url) }
+                )
             }
         }
     }


### PR DESCRIPTION
I am being a bit naughty and opening a PR without opening an issue first. So feel free to deny this if it's something you wouldn't like to add to DankChat.

This patch adds the "Paste" button familiar from the snackbar that opens when you copy a message to the snackbar that opens when you successfully uploaded an image. Very minor code change but something that has bothered me for a while now :)

I'm pretty inexperienced in actually writing Kotlin so feel free to criticize this any way you'd like