### PR TITLE
Format remaining timeout duration

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/service/twitch/message/Message.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/service/twitch/message/Message.kt
@@ -150,7 +150,15 @@ data class TwitchMessage(
 
         private fun parseNotice(message: IrcMessage): TwitchMessage = with(message) {
             val channel = params[0].substring(1)
-            val notice = params[1]
+
+            val notice = when {
+                tags["msg-id"] == "msg_timedout" -> {
+                    val duration = message.params[1].split(" ")[5]
+                    "You are timed out for ${DateTimeUtils.formatSeconds(duration)}."
+                }
+                else -> params[1]
+            }
+
             val ts = tags["rm-received-ts"]?.toLong() ?: System.currentTimeMillis()
             val id = tags["id"] ?: System.nanoTime().toString()
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/service/twitch/message/Message.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/service/twitch/message/Message.kt
@@ -153,8 +153,9 @@ data class TwitchMessage(
 
             val notice = when {
                 tags["msg-id"] == "msg_timedout" -> {
-                    val duration = message.params[1].split(" ")[5]
-                    "You are timed out for ${DateTimeUtils.formatSeconds(duration)}."
+                    message.params[1].split(" ").getOrNull(5)?.let {
+                        "You are timed out for ${DateTimeUtils.formatSeconds(it)}."
+                    } ?: params[1]
                 }
                 else -> params[1]
             }


### PR DESCRIPTION
This formats the remaining time a user is timed out in a chat in the same style as in #153.

If the NOTICE with msg_timedout as msg-id does not follow the current standard (less than 6 words), the connection reconnects.
Maybe this can be improved by using getOrNull and checking for Null specifically?