### PR TITLE
Filter URLs and Emotes from TTS

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -267,26 +267,17 @@ class NotificationService : Service(), CoroutineScope {
             previousTTSUser -> message
             else            -> messageFormat.also { previousTTSUser = name }
         }
-        ttsMessage = when {
-            removeURL -> {
-                val urlPattern = Pattern.compile("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)", Pattern.CASE_INSENSITIVE)
-                ttsMessage = ttsMessage.replace(urlPattern.toRegex(), "").trim()
-                ttsMessage
-            }
-            else -> ttsMessage
+        if (removeURL) {
+            val urlPattern = Pattern.compile("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)", Pattern.CASE_INSENSITIVE)
+            ttsMessage = ttsMessage.replace(urlPattern.toRegex(), "").trim()
         }
-        ttsMessage = when {
-            removeEmote -> {
-                val emotes = dataRepository.getEmotes(channel)
-                for (emote in emotes.value) {
-                    println(emote.code)
-                    if (ttsMessage.contains(emote.code, ignoreCase = true)) {
-                        ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
-                    }
+        if (removeEmote) {
+            for (emote in this.emotes) {
+                println(emote.code)
+                if (ttsMessage.contains(emote.code, ignoreCase = true)) {
+                    ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
                 }
-                ttsMessage
             }
-            else -> ttsMessage
         }
         tts?.speak(ttsMessage, queueMode, null, null)
     }

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -274,6 +274,7 @@ class NotificationService : Service(), CoroutineScope {
             for (emote in this.emotes) {
                 ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
             }
+            //Replaces all unicode emojis
             ttsMessage = ttsMessage.replace(Regex("(\\u00a9|\\u00ae|[\\u2000-\\u3300]|\\ud83c[\\ud000-\\udfff]|\\ud83d[\\ud000-\\udfff]|\\ud83e[\\ud000-\\udfff])"), "")
         }
         tts?.speak(ttsMessage, queueMode, null, null)

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -268,8 +268,7 @@ class NotificationService : Service(), CoroutineScope {
             else            -> messageFormat.also { previousTTSUser = name }
         }
         if (removeURL) {
-            val urlPattern = Pattern.compile("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)", Pattern.CASE_INSENSITIVE)
-            ttsMessage = ttsMessage.replace(urlPattern.toRegex(), "").trim()
+            ttsMessage = ttsMessage.replace("[(http(s)?):\\/\\/(www\\.)?a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)".toRegex(RegexOption.IGNORE_CASE), "")
         }
         if (removeEmote) {
             for (emote in this.emotes) {

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -272,9 +272,7 @@ class NotificationService : Service(), CoroutineScope {
         }
         if (removeEmote) {
             for (emote in this.emotes) {
-                if (ttsMessage.contains(emote.code, ignoreCase = true)) {
-                    ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
-                }
+                ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
             }
             ttsMessage = ttsMessage.replace(Regex("(\\u00a9|\\u00ae|[\\u2000-\\u3300]|\\ud83c[\\ud000-\\udfff]|\\ud83d[\\ud000-\\udfff]|\\ud83e[\\ud000-\\udfff])"), "")
         }

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -273,7 +273,6 @@ class NotificationService : Service(), CoroutineScope {
         }
         if (removeEmote) {
             for (emote in this.emotes) {
-                println(emote.code)
                 if (ttsMessage.contains(emote.code, ignoreCase = true)) {
                     ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
                 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -265,14 +265,8 @@ class NotificationService : Service(), CoroutineScope {
         }
         ttsMessage = when {
             removeURL -> {
-                val urlPattern = "((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)"
-                val p: Pattern = Pattern.compile(urlPattern, Pattern.CASE_INSENSITIVE)
-                val m: Matcher = p.matcher(ttsMessage)
-                var i = 0
-                while (m.find()) {
-                    ttsMessage = ttsMessage.replace(m.group(i), "").trim()
-                    i++
-                }
+                val urlPattern = Pattern.compile("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)", Pattern.CASE_INSENSITIVE)
+                ttsMessage = ttsMessage.replace(urlPattern.toRegex(), "").trim()
                 ttsMessage
             }
             else -> ttsMessage

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -12,10 +12,15 @@ import android.os.Binder
 import android.os.Build
 import android.os.IBinder
 import android.speech.tts.TextToSpeech
+import androidx.appcompat.widget.EmojiCompatConfigurationView
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
+import androidx.emoji2.text.EmojiCompat
+import androidx.emoji2.text.EmojiCompatInitializer
+import androidx.emoji2.text.EmojiDefaults
+import androidx.emoji2.text.EmojiMetadata
 import androidx.media.app.NotificationCompat.MediaStyle
 import androidx.preference.PreferenceManager
 import com.flxrs.dankchat.R
@@ -26,6 +31,7 @@ import com.flxrs.dankchat.data.twitch.message.WhisperMessage
 import com.flxrs.dankchat.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
+import java.io.Console
 import java.util.*
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -271,9 +277,11 @@ class NotificationService : Service(), CoroutineScope {
             for (emote in this.emotes) {
                 ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
             }
-            //Replaces all unicode emojis
-            ttsMessage = ttsMessage.replace(Regex("(\\u00a9|\\u00ae|[\\u2000-\\u3300]|\\ud83c[\\ud000-\\udfff]|\\ud83d[\\ud000-\\udfff]|\\ud83e[\\ud000-\\udfff])"), "")
+            //Replaces all unicode character that are: So - Symbol Other, Sc - Symbol Currency, Sm - Symbol Math, Cn - Unassigned.
+            //This will not filter out non latin script (Arabic and Japanese for example works fine.)
+            ttsMessage = ttsMessage.replace("\\p{So}|\\p{Sc}|\\p{Sm}|\\p{Cn}".toRegex(), "")
         }
+
         tts?.speak(ttsMessage, queueMode, null, null)
     }
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -26,10 +26,7 @@ import com.flxrs.dankchat.data.twitch.message.WhisperMessage
 import com.flxrs.dankchat.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.forEach
 import java.util.*
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -45,8 +42,8 @@ class NotificationService : Service(), CoroutineScope {
             getString(R.string.preference_tts_queue_key)                -> ttsMessageQueue = sharedPreferences.getBoolean(key, true)
             getString(R.string.preference_tts_message_format_key)       -> combinedTTSFormat = sharedPreferences.getBoolean(key, true)
             getString(R.string.preference_tts_key)                      -> ttsEnabled = sharedPreferences.getBoolean(key, false).also { setTTSEnabled(it) }
-            getString(R.string.preference_tts_message_filter_url_key)   -> removeURL = sharedPreferences.getBoolean(key, false)
-            getString(R.string.preference_tts_message_filter_emote_key) -> removeEmote = sharedPreferences.getBoolean(key, false)
+            getString(R.string.preference_tts_message_ignore_url_key)   -> removeURL = sharedPreferences.getBoolean(key, false)
+            getString(R.string.preference_tts_message_ignore_emote_key) -> removeEmote = sharedPreferences.getBoolean(key, false)
             getString(R.string.preference_tts_user_ignore_list_key)     -> ignoredTtsUsers = sharedPreferences.getStringSet(key, emptySet()).orEmpty()
             getString(R.string.preference_tts_force_english_key)        -> {
                 forceEnglishTTS = sharedPreferences.getBoolean(key, false)
@@ -124,8 +121,8 @@ class NotificationService : Service(), CoroutineScope {
             combinedTTSFormat = sharedPreferences.getBoolean(getString(R.string.preference_tts_message_format_key), true)
             forceEnglishTTS = sharedPreferences.getBoolean(getString(R.string.preference_tts_force_english_key), false)
             ttsEnabled = sharedPreferences.getBoolean(getString(R.string.preference_tts_key), false).also { setTTSEnabled(it) }
-            removeURL = sharedPreferences.getBoolean(getString(R.string.preference_tts_message_filter_url_key), false)
-            removeEmote = sharedPreferences.getBoolean(getString(R.string.preference_tts_message_filter_emote_key), false)
+            removeURL = sharedPreferences.getBoolean(getString(R.string.preference_tts_message_ignore_url_key), false)
+            removeEmote = sharedPreferences.getBoolean(getString(R.string.preference_tts_message_ignore_emote_key), false)
             ignoredTtsUsers = sharedPreferences.getStringSet(getString(R.string.preference_tts_user_ignore_list_key), emptySet()).orEmpty()
             registerOnSharedPreferenceChangeListener(preferenceListener)
         }

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/NotificationService.kt
@@ -277,6 +277,7 @@ class NotificationService : Service(), CoroutineScope {
                     ttsMessage = ttsMessage.replace(emote.code, "", ignoreCase = true)
                 }
             }
+            ttsMessage = ttsMessage.replace(Regex("(\\u00a9|\\u00ae|[\\u2000-\\u3300]|\\ud83c[\\ud000-\\udfff]|\\ud83d[\\ud000-\\udfff]|\\ud83e[\\ud000-\\udfff])"), "")
         }
         tts?.speak(ttsMessage, queueMode, null, null)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,10 @@
     <string name="preference_tts_message_format_combined">Reads out user and message</string>
     <string name="preference_tts_message_format_key" translatable="false">tts_message_format_key</string>
     <string name="preference_tts_message_format_title">Message format mode</string>
+    <string name="preference_tts_message_filter_url_message">Reads out URLs</string>
+    <string name="preference_tts_message_filter_url_message_filter">Removes URLs from TTS</string>
+    <string name="preference_tts_message_filter_url_key" translatable="false">tts_message_filter_url</string>
+    <string name="preference_tts_message_filter_url_title">Filter URLs</string>
     <string name="preference_tts_header">TTS</string>
     <string name="checkered_messages_key" translatable="false">checkered_messages</string>
     <string name="preference_checkered_lines_title">Checkered Lines</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,12 +253,12 @@
     <string name="preference_tts_message_format_combined">Reads out user and message</string>
     <string name="preference_tts_message_format_key" translatable="false">tts_message_format_key</string>
     <string name="preference_tts_message_format_title">Message format mode</string>
-    <string name="preference_tts_message_filter_url_message">Ignores URLs in TTS</string>
-    <string name="preference_tts_message_filter_url_key" translatable="false">tts_message_filter_url</string>
-    <string name="preference_tts_message_filter_url_title">Filter URLs</string>
-    <string name="preference_tts_message_filter_emote_message">Ignores emotes and emojis in TTS</string>
-    <string name="preference_tts_message_filter_emote_key" translatable="false">tts_message_filter_emote</string>
-    <string name="preference_tts_message_filter_emote_title">Filter emotes</string>
+    <string name="preference_tts_message_ignore_url_message">Ignores URLs in TTS</string>
+    <string name="preference_tts_message_ignore_url_key" translatable="false">tts_message_ignore_url</string>
+    <string name="preference_tts_message_ignore_url_title">Ignore URLs</string>
+    <string name="preference_tts_message_ignore_emote_message">Ignores emotes and emojis in TTS</string>
+    <string name="preference_tts_message_ignore_emote_key" translatable="false">tts_message_ignore_emote</string>
+    <string name="preference_tts_message_ignore_emote_title">Ignore emotes</string>
     <string name="preference_tts_header">TTS</string>
     <string name="checkered_messages_key" translatable="false">checkered_messages</string>
     <string name="preference_checkered_lines_title">Checkered Lines</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,10 @@
     <string name="preference_tts_message_filter_url_message_filter">Removes URLs from TTS</string>
     <string name="preference_tts_message_filter_url_key" translatable="false">tts_message_filter_url</string>
     <string name="preference_tts_message_filter_url_title">Filter URLs</string>
+    <string name="preference_tts_message_filter_emote_message">Reads out emotes</string>
+    <string name="preference_tts_message_filter_emote_message_filter">Removes emotes from TTS</string>
+    <string name="preference_tts_message_filter_emote_key" translatable="false">tts_message_filter_emote</string>
+    <string name="preference_tts_message_filter_emote_title">Filter emotes</string>
     <string name="preference_tts_header">TTS</string>
     <string name="checkered_messages_key" translatable="false">checkered_messages</string>
     <string name="preference_checkered_lines_title">Checkered Lines</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,12 +253,10 @@
     <string name="preference_tts_message_format_combined">Reads out user and message</string>
     <string name="preference_tts_message_format_key" translatable="false">tts_message_format_key</string>
     <string name="preference_tts_message_format_title">Message format mode</string>
-    <string name="preference_tts_message_filter_url_message">Reads out URLs</string>
-    <string name="preference_tts_message_filter_url_message_filter">Removes URLs from TTS</string>
+    <string name="preference_tts_message_filter_url_message">Ignores URLs in TTS</string>
     <string name="preference_tts_message_filter_url_key" translatable="false">tts_message_filter_url</string>
     <string name="preference_tts_message_filter_url_title">Filter URLs</string>
-    <string name="preference_tts_message_filter_emote_message">Reads out emotes</string>
-    <string name="preference_tts_message_filter_emote_message_filter">Removes emotes from TTS</string>
+    <string name="preference_tts_message_filter_emote_message">Ignores emotes and emojis in TTS</string>
     <string name="preference_tts_message_filter_emote_key" translatable="false">tts_message_filter_emote</string>
     <string name="preference_tts_message_filter_emote_title">Filter emotes</string>
     <string name="preference_tts_header">TTS</string>

--- a/app/src/main/res/xml/tools_settings.xml
+++ b/app/src/main/res/xml/tools_settings.xml
@@ -50,6 +50,17 @@
             android:title="@string/preference_tts_force_english_title"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:dependency="@string/preference_tts_key"
+            android:key="@string/preference_tts_message_filter_url_key"
+            android:summaryOff="@string/preference_tts_message_filter_url_message"
+            android:summaryOn="@string/preference_tts_message_filter_url_message_filter"
+            android:title="@string/preference_tts_message_filter_url_title"
+            app:iconSpaceReserved="false"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/switchPreferenceCompat" />
         <Preference
             android:dependency="@string/preference_tts_key"
             android:key="@string/preference_tts_user_ignore_list_key"

--- a/app/src/main/res/xml/tools_settings.xml
+++ b/app/src/main/res/xml/tools_settings.xml
@@ -53,17 +53,17 @@
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:dependency="@string/preference_tts_key"
-            android:key="@string/preference_tts_message_filter_url_key"
-            android:title="@string/preference_tts_message_filter_url_title"
+            android:key="@string/preference_tts_message_ignore_url_key"
+            android:title="@string/preference_tts_message_ignore_url_title"
             app:iconSpaceReserved="false"
-            android:summary="@string/preference_tts_message_filter_url_message" />
+            android:summary="@string/preference_tts_message_ignore_url_message" />
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:dependency="@string/preference_tts_key"
-            android:key="@string/preference_tts_message_filter_emote_key"
-            android:title="@string/preference_tts_message_filter_emote_title"
+            android:key="@string/preference_tts_message_ignore_emote_key"
+            android:title="@string/preference_tts_message_ignore_emote_title"
             app:iconSpaceReserved="false"
-            android:summary="@string/preference_tts_message_filter_emote_message" />
+            android:summary="@string/preference_tts_message_ignore_emote_message" />
         <Preference
             android:dependency="@string/preference_tts_key"
             android:key="@string/preference_tts_user_ignore_list_key"

--- a/app/src/main/res/xml/tools_settings.xml
+++ b/app/src/main/res/xml/tools_settings.xml
@@ -57,10 +57,15 @@
             android:summaryOff="@string/preference_tts_message_filter_url_message"
             android:summaryOn="@string/preference_tts_message_filter_url_message_filter"
             android:title="@string/preference_tts_message_filter_url_title"
-            app:iconSpaceReserved="false"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/switchPreferenceCompat" />
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:dependency="@string/preference_tts_key"
+            android:key="@string/preference_tts_message_filter_emote_key"
+            android:summaryOff="@string/preference_tts_message_filter_emote_message"
+            android:summaryOn="@string/preference_tts_message_filter_emote_message_filter"
+            android:title="@string/preference_tts_message_filter_emote_title"
+            app:iconSpaceReserved="false" />
         <Preference
             android:dependency="@string/preference_tts_key"
             android:key="@string/preference_tts_user_ignore_list_key"

--- a/app/src/main/res/xml/tools_settings.xml
+++ b/app/src/main/res/xml/tools_settings.xml
@@ -54,18 +54,16 @@
             android:defaultValue="false"
             android:dependency="@string/preference_tts_key"
             android:key="@string/preference_tts_message_filter_url_key"
-            android:summaryOff="@string/preference_tts_message_filter_url_message"
-            android:summaryOn="@string/preference_tts_message_filter_url_message_filter"
             android:title="@string/preference_tts_message_filter_url_title"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            android:summary="@string/preference_tts_message_filter_url_message" />
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:dependency="@string/preference_tts_key"
             android:key="@string/preference_tts_message_filter_emote_key"
-            android:summaryOff="@string/preference_tts_message_filter_emote_message"
-            android:summaryOn="@string/preference_tts_message_filter_emote_message_filter"
             android:title="@string/preference_tts_message_filter_emote_title"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            android:summary="@string/preference_tts_message_filter_emote_message" />
         <Preference
             android:dependency="@string/preference_tts_key"
             android:key="@string/preference_tts_user_ignore_list_key"


### PR DESCRIPTION
Fixes #257

- [x] Filter URLs from TTS
- [x] Filter Emotes from TTS

Both add options under the TTS section of the setting (Settings -> Tools -> TTS). Both are filtered with regex.