### PR TITLE
Add confirmation to various actions (#324)

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -17,9 +17,8 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.activity.result.contract.ActivityResultContracts.*
-import androidx.activity.result.launch
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -57,7 +56,6 @@ import com.flxrs.dankchat.data.twitch.emote.GenericEmote
 import com.flxrs.dankchat.databinding.EditDialogBinding
 import com.flxrs.dankchat.databinding.MainFragmentBinding
 import com.flxrs.dankchat.preferences.DankChatPreferenceStore
-import com.flxrs.dankchat.utils.GetImageOrVideoContract
 import com.flxrs.dankchat.utils.createMediaFile
 import com.flxrs.dankchat.utils.extensions.*
 import com.flxrs.dankchat.utils.removeExifAttributes
@@ -835,8 +833,15 @@ class MainFragment : Fragment() {
     private fun removeChannel() {
         val activeChannel = mainViewModel.getActiveChannel() ?: return
         val channels = mainViewModel.getChannels().ifEmpty { return }
-        val updatedChannels = channels - activeChannel
-        updateChannels(updatedChannels)
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.confirm_channel_removal_title)
+            .setMessage(R.string.confirm_channel_removal_message)
+            .setPositiveButton(R.string.confirm_channel_removal_positive_button) { dialog, _ ->
+                val updatedChannels = channels - activeChannel
+                updateChannels(updatedChannels)
+            }
+            .setNegativeButton(R.string.dialog_cancel) { _, _ -> }
+            .create().show()
     }
 
     private fun openManageChannelsDialog() {

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -835,6 +835,7 @@ class MainFragment : Fragment() {
         val channels = mainViewModel.getChannels().ifEmpty { return }
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.confirm_channel_removal_title)
+            // should give user more info that it's gonna delete the currently active channel (unlike when clicking delete from manage channels list, where is very obvious)
             .setMessage(getString(R.string.confirm_channel_removal_message_named, activeChannel))
             .setPositiveButton(R.string.confirm_channel_removal_positive_button) { dialog, _ ->
                 val updatedChannels = channels - activeChannel

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -835,7 +835,7 @@ class MainFragment : Fragment() {
         val channels = mainViewModel.getChannels().ifEmpty { return }
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.confirm_channel_removal_title)
-            .setMessage(R.string.confirm_channel_removal_message)
+            .setMessage(getString(R.string.confirm_channel_removal_message_named, activeChannel))
             .setPositiveButton(R.string.confirm_channel_removal_positive_button) { dialog, _ ->
                 val updatedChannels = channels - activeChannel
                 updateChannels(updatedChannels)

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/ToolsSettingsFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/ToolsSettingsFragment.kt
@@ -97,10 +97,10 @@ class ToolsSettingsFragment : MaterialPreferenceFragmentCompat() {
             uploader = dankChatPreferenceStore.customImageUploader
             uploaderReset.setOnClickListener {
                 MaterialAlertDialogBuilder(context)
-                    .setTitle(getString(R.string.reset_image_uploader_dialog_title))
-                    .setMessage(getString(R.string.reset_image_uploader_dialog_message))
-                    .setPositiveButton(getString(R.string.reset_image_uploader_dialog_positive)) { _, _ -> uploader = dankChatPreferenceStore.resetImageUploader()}
-                    .setNegativeButton(getString(R.string.dialog_cancel)) {_, _ -> }
+                    .setTitle(R.string.reset_image_uploader_dialog_title)
+                    .setMessage(R.string.reset_image_uploader_dialog_message)
+                    .setPositiveButton(R.string.reset_image_uploader_dialog_positive) { _, _ -> uploader = dankChatPreferenceStore.resetImageUploader()}
+                    .setNegativeButton(R.string.dialog_cancel) {_, _ -> }
                     .create().show()
             }
             uploaderSheet.updateLayoutParams {
@@ -179,10 +179,10 @@ class ToolsSettingsFragment : MaterialPreferenceFragmentCompat() {
             }
             clearUploads.setOnClickListener {
                 MaterialAlertDialogBuilder(context)
-                    .setTitle(getString(R.string.clear_recent_uploads_dialog_title))
-                    .setMessage(getString(R.string.clear_recent_uploads_dialog_message))
-                    .setPositiveButton(getString(R.string.clear_recent_uploads_dialog_positive)) { _, _ -> viewModel.clearUploads()}
-                    .setNegativeButton(getString(R.string.dialog_cancel)){_, _ -> }
+                    .setTitle(R.string.clear_recent_uploads_dialog_title)
+                    .setMessage(R.string.clear_recent_uploads_dialog_message)
+                    .setPositiveButton(R.string.clear_recent_uploads_dialog_positive) { _, _ -> viewModel.clearUploads()}
+                    .setNegativeButton(R.string.dialog_cancel){_, _ -> }
                     .create().show()
             }
         }

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/ToolsSettingsFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/ToolsSettingsFragment.kt
@@ -97,9 +97,9 @@ class ToolsSettingsFragment : MaterialPreferenceFragmentCompat() {
             uploader = dankChatPreferenceStore.customImageUploader
             uploaderReset.setOnClickListener {
                 MaterialAlertDialogBuilder(context)
-                    .setTitle(R.string.reset_image_uploader_dialog_title)
-                    .setMessage(R.string.reset_image_uploader_dialog_message)
-                    .setPositiveButton(R.string.reset_image_uploader_dialog_positive) { _, _ -> uploader = dankChatPreferenceStore.resetImageUploader()}
+                    .setTitle(R.string.reset_media_uploader_dialog_title)
+                    .setMessage(R.string.reset_media_uploader_dialog_message)
+                    .setPositiveButton(R.string.reset_media_uploader_dialog_positive) { _, _ -> uploader = dankChatPreferenceStore.resetImageUploader()}
                     .setNegativeButton(R.string.dialog_cancel) {_, _ -> }
                     .create().show()
             }

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/ToolsSettingsFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/ToolsSettingsFragment.kt
@@ -30,6 +30,7 @@ import com.flxrs.dankchat.preferences.tts.TtsIgnoreListAdapter
 import com.flxrs.dankchat.preferences.upload.RecentUploadsAdapter
 import com.flxrs.dankchat.preferences.upload.RecentUploadsViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.math.roundToInt
@@ -95,7 +96,12 @@ class ToolsSettingsFragment : MaterialPreferenceFragmentCompat() {
         val binding = UploaderBottomsheetBinding.inflate(LayoutInflater.from(context), root as? ViewGroup, false).apply {
             uploader = dankChatPreferenceStore.customImageUploader
             uploaderReset.setOnClickListener {
-                uploader = dankChatPreferenceStore.resetImageUploader()
+                MaterialAlertDialogBuilder(context)
+                    .setTitle(getString(R.string.reset_image_uploader_dialog_title))
+                    .setMessage(getString(R.string.reset_image_uploader_dialog_message))
+                    .setPositiveButton(getString(R.string.reset_image_uploader_dialog_positive)) { _, _ -> uploader = dankChatPreferenceStore.resetImageUploader()}
+                    .setNegativeButton(getString(R.string.dialog_cancel)) {_, _ -> }
+                    .create().show()
             }
             uploaderSheet.updateLayoutParams {
                 height = windowHeight
@@ -172,7 +178,12 @@ class ToolsSettingsFragment : MaterialPreferenceFragmentCompat() {
                 height = windowHeight
             }
             clearUploads.setOnClickListener {
-                viewModel.clearUploads()
+                MaterialAlertDialogBuilder(context)
+                    .setTitle(getString(R.string.clear_recent_uploads_dialog_title))
+                    .setMessage(getString(R.string.clear_recent_uploads_dialog_message))
+                    .setPositiveButton(getString(R.string.clear_recent_uploads_dialog_positive)) { _, _ -> viewModel.clearUploads()}
+                    .setNegativeButton(getString(R.string.dialog_cancel)){_, _ -> }
+                    .create().show()
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,7 +332,7 @@
     <string name="reset_image_uploader_dialog_message">Are you sure you want to reset the Image Uploader settings to default?</string>
     <string name="reset_image_uploader_dialog_positive">Reset</string>
     <string name="clear_recent_uploads_dialog_title">Clear Recent Uploads</string>
-    <string name="clear_recent_uploads_dialog_message">Are you sure you want to clear the upload history?</string>
+    <string name="clear_recent_uploads_dialog_message">Are you sure you want to clear the upload history? Your uploaded files won\'t be deleted.</string>
     <string name="clear_recent_uploads_dialog_positive">Clear</string>
     <plurals name="viewers">
         <item quantity="one">Live with %d viewer</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="uploader_headers">Headers</string>
     <string name="uploader_image_link">Media link pattern</string>
     <string name="uploader_deletion_link">Deletion link pattern</string>
-    <string name="uploader_description">You can set a custom host for uploading media, like imgur.com or s-ul.eu. DankChat uses the same configuration format as Chatterino.\nCheck this guide for help: https://wiki.chatterino.com/image%20Uploader/</string>
+    <string name="uploader_description">You can set a custom host for uploading media, like imgur.com or s-ul.eu. DankChat uses the same configuration format as Chatterino.\nCheck this guide for help: https://wiki.chatterino.com/Image%20Uploader/</string>
     <string name="toggle_fullscreen">Toggle fullscreen</string>
     <string name="toggle_stream">Toggle stream</string>
     <string name="account">Account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,7 +89,7 @@
     <string name="mentions">Mentions</string>
     <string name="confirm_channel_removal_title">Confirm channel removal</string>
     <string name="confirm_channel_removal_message">Are you sure you want to remove this channel?</string>
-    <string name="confirm_channel_removal_message_named">Are you sure you want to remove channel "%1$s"?</string>
+    <string name="confirm_channel_removal_message_named">Are you sure you want to remove channel \"%1$s\"?</string>
     <string name="confirm_channel_removal_positive_button">Remove</string>
     <string name="user_popup_follow">Follow</string>
     <string name="user_popup_unfollow">Unfollow</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="uploader_headers">Headers</string>
     <string name="uploader_image_link">Media link pattern</string>
     <string name="uploader_deletion_link">Deletion link pattern</string>
-    <string name="uploader_description">You can set a custom host for uploading media, like imgur.com or s-ul.eu. DankChat uses the same configuration format as Chatterino.\nCheck this guide for help: https://wiki.chatterino.com/Image%20Uploader/</string>
+    <string name="uploader_description">You can set a custom host for uploading media, like imgur.com or s-ul.eu. DankChat uses the same configuration format as Chatterino.\nCheck this guide for help: https://wiki.chatterino.com/image%20Uploader/</string>
     <string name="toggle_fullscreen">Toggle fullscreen</string>
     <string name="toggle_stream">Toggle stream</string>
     <string name="account">Account</string>
@@ -328,9 +328,9 @@
     <string name="preference_retain_webview_key" translatable="false">retain_webview_key</string>
     <string name="preference_retain_webview_title">Prevent stream reloads</string>
     <string name="preference_retain_webview_summary">Enables experimental prevention of stream reloads after orientation changes or re-opening DankChat.</string>
-    <string name="reset_image_uploader_dialog_title">Reset Image Uploader Settings</string>
-    <string name="reset_image_uploader_dialog_message">Are you sure you want to reset the Image Uploader settings to default?</string>
-    <string name="reset_image_uploader_dialog_positive">Reset</string>
+    <string name="reset_media_uploader_dialog_title">Reset Media Uploader Settings</string>
+    <string name="reset_media_uploader_dialog_message">Are you sure you want to reset the media uploader settings to default?</string>
+    <string name="reset_media_uploader_dialog_positive">Reset</string>
     <string name="clear_recent_uploads_dialog_title">Clear Recent Uploads</string>
     <string name="clear_recent_uploads_dialog_message">Are you sure you want to clear the upload history? Your uploaded files won\'t be deleted.</string>
     <string name="clear_recent_uploads_dialog_positive">Clear</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="mentions">Mentions</string>
     <string name="confirm_channel_removal_title">Confirm channel removal</string>
     <string name="confirm_channel_removal_message">Are you sure you want to remove this channel?</string>
+    <string name="confirm_channel_removal_message_named">Are you sure you want to remove channel "%1$s"?</string>
     <string name="confirm_channel_removal_positive_button">Remove</string>
     <string name="user_popup_follow">Follow</string>
     <string name="user_popup_unfollow">Unfollow</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,12 @@
     <string name="preference_retain_webview_key" translatable="false">retain_webview_key</string>
     <string name="preference_retain_webview_title">Prevent stream reloads</string>
     <string name="preference_retain_webview_summary">Enables experimental prevention of stream reloads after orientation changes or re-opening DankChat.</string>
+    <string name="reset_image_uploader_dialog_title">Reset Image Uploader Settings</string>
+    <string name="reset_image_uploader_dialog_message">Are you sure you want to reset the Image Uploader settings to default?</string>
+    <string name="reset_image_uploader_dialog_positive">Reset</string>
+    <string name="clear_recent_uploads_dialog_title">Clear Recent Uploads</string>
+    <string name="clear_recent_uploads_dialog_message">Are you sure you want to clear the upload history?</string>
+    <string name="clear_recent_uploads_dialog_positive">Clear</string>
     <plurals name="viewers">
         <item quantity="one">Live with %d viewer</item>
         <item quantity="other">Live with %d viewers</item>


### PR DESCRIPTION
Fixes #324 

Add confirmation dialogs when:
- deleting channels through the overflow menu ( `Overflow Menu -> Channel -> Remove Channel)
- resettings image uploader settings
- clearing upload