### PR TITLE
Make custom media upload warning show corresponding website instead of i.nuuls.com

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -671,7 +671,7 @@ class MainFragment : Fragment() {
         } .getOrElse { "" }
 
         // if config is invalid, just let the error handled by HTTP client
-        if (host != "" && !dankChatPreferences.hasExternalHostingAcknowledged) {
+        if (host.isNotBlank() && !dankChatPreferences.hasExternalHostingAcknowledged) {
             val spannable = SpannableStringBuilder(getString(R.string.external_upload_disclaimer, host))
             Linkify.addLinks(spannable, Linkify.WEB_URLS)
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -680,7 +680,7 @@ class MainFragment : Fragment() {
         }
 
         if (!dankChatPreferences.hasExternalHostingAcknowledged) {
-            val spannable = SpannableStringBuilder(getString(R.string.nuuls_upload_disclaimer, host))
+            val spannable = SpannableStringBuilder(getString(R.string.external_upload_disclaimer, host))
             Linkify.addLinks(spannable, Linkify.WEB_URLS)
 
             MaterialAlertDialogBuilder(requireContext())

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -17,9 +17,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.*
-import androidx.activity.result.launch
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -57,7 +55,6 @@ import com.flxrs.dankchat.data.twitch.emote.GenericEmote
 import com.flxrs.dankchat.databinding.EditDialogBinding
 import com.flxrs.dankchat.databinding.MainFragmentBinding
 import com.flxrs.dankchat.preferences.DankChatPreferenceStore
-import com.flxrs.dankchat.utils.GetImageOrVideoContract
 import com.flxrs.dankchat.utils.createMediaFile
 import com.flxrs.dankchat.utils.extensions.*
 import com.flxrs.dankchat.utils.removeExifAttributes
@@ -667,12 +664,18 @@ class MainFragment : Fragment() {
 
     private inline fun showNuulsUploadDialogIfNotAcknowledged(crossinline action: () -> Unit) {
         if (!dankChatPreferences.hasNuulsAcknowledged) {
-            val spannable = SpannableStringBuilder(getString(R.string.nuuls_upload_disclaimer))
+            // have URL without query string to make it looks nicer (e.g. s-ul.eu upload have api key in query string!)
+            val uploadUrlWithoutQuery = dankChatPreferences.customImageUploader.uploadUrl.let{
+                if (!it.contains('?')) it
+                else it.substring(0, it.indexOf('?'))
+            }
+
+            val spannable = SpannableStringBuilder(getString(R.string.external_upload_disclaimer, uploadUrlWithoutQuery))
             Linkify.addLinks(spannable, Linkify.WEB_URLS)
 
             MaterialAlertDialogBuilder(requireContext())
                 .setCancelable(false)
-                .setTitle(R.string.nuuls_upload_title)
+                .setTitle(R.string.external_upload_title)
                 .setMessage(spannable)
                 .setPositiveButton(R.string.dialog_ok) { dialog, _ ->
                     dialog.dismiss()

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -670,12 +670,12 @@ class MainFragment : Fragment() {
                 else it.substring(0, it.indexOf('?'))
             }
 
-            val spannable = SpannableStringBuilder(getString(R.string.external_upload_disclaimer, uploadUrlWithoutQuery))
+            val spannable = SpannableStringBuilder(getString(R.string.nuuls_upload_disclaimer, uploadUrlWithoutQuery))
             Linkify.addLinks(spannable, Linkify.WEB_URLS)
 
             MaterialAlertDialogBuilder(requireContext())
                 .setCancelable(false)
-                .setTitle(R.string.external_upload_title)
+                .setTitle(R.string.nuuls_upload_title)
                 .setMessage(spannable)
                 .setPositiveButton(R.string.dialog_ok) { dialog, _ ->
                     dialog.dismiss()

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -670,17 +670,8 @@ class MainFragment : Fragment() {
             URL(dankChatPreferences.customImageUploader.uploadUrl).host
         } .getOrElse { "" }
 
-        if (host.isEmpty()) {
-            MaterialAlertDialogBuilder(requireContext())
-                .setTitle(R.string.invalid_media_url_title)
-                .setMessage(getString(R.string.invalid_media_url_message, dankChatPreferences.customImageUploader.uploadUrl))
-                .setPositiveButton(R.string.dialog_ok) { _, _ -> }
-                .create()
-                .show()
-            return
-        }
-
-        if (!dankChatPreferences.hasExternalHostingAcknowledged) {
+        // if config is invalid, just let the error handled by HTTP client
+        if (host != "" && !dankChatPreferences.hasExternalHostingAcknowledged) {
             val spannable = SpannableStringBuilder(getString(R.string.external_upload_disclaimer, host))
             Linkify.addLinks(spannable, Linkify.WEB_URLS)
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainFragment.kt
@@ -243,7 +243,7 @@ class MainFragment : Fragment() {
                     R.id.menu_block_channel  -> blockChannel()
                     R.id.menu_manage         -> openManageChannelsDialog()
                     R.id.menu_reload_emotes  -> reloadEmotes()
-                    R.id.menu_choose_media   -> showNuulsUploadDialogIfNotAcknowledged { requestGalleryMedia.launch(PickVisualMediaRequest(PickVisualMedia.ImageAndVideo)) }
+                    R.id.menu_choose_media   -> showExternalHostingUploadDialogIfNotAcknowledged { requestGalleryMedia.launch(PickVisualMediaRequest(PickVisualMedia.ImageAndVideo)) }
                     R.id.menu_capture_image  -> startCameraCapture()
                     R.id.menu_capture_video  -> startCameraCapture(captureVideo = true)
                     R.id.menu_clear          -> clear()
@@ -662,8 +662,8 @@ class MainFragment : Fragment() {
         suggestionAdapter.setSuggestions(suggestions)
     }
 
-    private inline fun showNuulsUploadDialogIfNotAcknowledged(crossinline action: () -> Unit) {
-        if (!dankChatPreferences.hasNuulsAcknowledged) {
+    private inline fun showExternalHostingUploadDialogIfNotAcknowledged(crossinline action: () -> Unit) {
+        if (!dankChatPreferences.hasExternalHostingAcknowledged) {
             // have URL without query string to make it looks nicer (e.g. s-ul.eu upload have api key in query string!)
             val uploadUrlWithoutQuery = dankChatPreferences.customImageUploader.uploadUrl.let{
                 if (!it.contains('?')) it
@@ -679,7 +679,7 @@ class MainFragment : Fragment() {
                 .setMessage(spannable)
                 .setPositiveButton(R.string.dialog_ok) { dialog, _ ->
                     dialog.dismiss()
-                    dankChatPreferences.hasNuulsAcknowledged = true
+                    dankChatPreferences.hasExternalHostingAcknowledged = true
                     action()
                 }
                 .show().also { it.findViewById<TextView>(android.R.id.message)?.movementMethod = LinkMovementMethod.getInstance() }
@@ -694,7 +694,7 @@ class MainFragment : Fragment() {
             captureVideo -> MediaStore.ACTION_VIDEO_CAPTURE to "mp4"
             else         -> MediaStore.ACTION_IMAGE_CAPTURE to "jpg"
         }
-        showNuulsUploadDialogIfNotAcknowledged {
+        showExternalHostingUploadDialogIfNotAcknowledged {
             Intent(action).also { captureIntent ->
                 captureIntent.resolveActivity(packageManager)?.also {
                     try {

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
@@ -54,9 +54,9 @@ class DankChatPreferenceStore @Inject constructor(private val context: Context) 
         get() = dankChatPreferences.getString(ID_STRING_KEY, null)
         set(value) = dankChatPreferences.edit { putString(ID_STRING_KEY, value) }
 
-    var hasNuulsAcknowledged: Boolean
-        get() = dankChatPreferences.getBoolean(NUULS_ACK_KEY, false)
-        set(value) = dankChatPreferences.edit { putBoolean(NUULS_ACK_KEY, value) }
+    var hasExternalHostingAcknowledged: Boolean
+        get() = dankChatPreferences.getBoolean(EXTERNAL_HOSTING_ACK_KEY, false)
+        set(value) = dankChatPreferences.edit { putBoolean(EXTERNAL_HOSTING_ACK_KEY, value) }
 
     var hasMessageHistoryAcknowledged: Boolean
         get() = dankChatPreferences.getBoolean(MESSAGES_HISTORY_ACK_KEY, false)
@@ -289,7 +289,7 @@ class DankChatPreferenceStore @Inject constructor(private val context: Context) 
         private const val CHANNELS_AS_STRING_KEY = "channelsAsStringKey"
         private const val ID_KEY = "idKey"
         private const val ID_STRING_KEY = "idStringKey"
-        private const val NUULS_ACK_KEY = "nuulsAckKey"
+        private const val EXTERNAL_HOSTING_ACK_KEY = "externalHostingAckKey"
         private const val MESSAGES_HISTORY_ACK_KEY = "messageHistoryAckKey"
 
         private const val UPLOADER_URL = "uploaderUrl"

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
@@ -289,7 +289,7 @@ class DankChatPreferenceStore @Inject constructor(private val context: Context) 
         private const val CHANNELS_AS_STRING_KEY = "channelsAsStringKey"
         private const val ID_KEY = "idKey"
         private const val ID_STRING_KEY = "idStringKey"
-        private const val EXTERNAL_HOSTING_ACK_KEY = "externalHostingAckKey"
+        private const val EXTERNAL_HOSTING_ACK_KEY = "nuulsAckKey" // the key is old key to prevent triggering the dialog for existing users
         private const val MESSAGES_HISTORY_ACK_KEY = "messageHistoryAckKey"
 
         private const val UPLOADER_URL = "uploaderUrl"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -28,7 +28,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">تحميل الصورة</string>
     <string name="settings">إلاعدادات</string>
-    <string name="nuuls_upload_disclaimer">لاستضافة الخارجية مقدمة من %1$s ، استخدمها على مسؤوليتك الخاصة.</string>
+    <string name="nuuls_upload_disclaimer">لاستضافة الخارجية مقدمة من https://nuuls.com/i ، استخدمها على مسؤوليتك الخاصة.</string>
+    <string name="external_upload_disclaimer">لاستضافة الخارجية مقدمة من %1$s ، استخدمها على مسؤوليتك الخاصة.</string>
     <string name="nuuls_upload_title">تحميل صورة مخصصة</string>
     <string name="snackbar_message_copied">تم نسخ الرسالة</string>
     <string name="snackbar_error_copied">Error information copied</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -28,8 +28,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">تحميل الصورة</string>
     <string name="settings">إلاعدادات</string>
-    <string name="external_upload_disclaimer">لاستضافة الخارجية مقدمة من https://nuuls.com/i ، استخدمها على مسؤوليتك الخاصة.</string>
-    <string name="external_upload_title">تحميل صورة مخصصة</string>
+    <string name="nuuls_upload_disclaimer">لاستضافة الخارجية مقدمة من %1$s ، استخدمها على مسؤوليتك الخاصة.</string>
+    <string name="nuuls_upload_title">تحميل صورة مخصصة</string>
     <string name="snackbar_message_copied">تم نسخ الرسالة</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -28,8 +28,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">تحميل الصورة</string>
     <string name="settings">إلاعدادات</string>
-    <string name="nuuls_upload_disclaimer">لاستضافة الخارجية مقدمة من https://nuuls.com/i ، استخدمها على مسؤوليتك الخاصة.</string>
-    <string name="nuuls_upload_title">تحميل صورة مخصصة</string>
+    <string name="external_upload_disclaimer">لاستضافة الخارجية مقدمة من https://nuuls.com/i ، استخدمها على مسؤوليتك الخاصة.</string>
+    <string name="external_upload_title">تحميل صورة مخصصة</string>
     <string name="snackbar_message_copied">تم نسخ الرسالة</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-b+zh+Hant+TW/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant+TW/strings.xml
@@ -29,8 +29,8 @@
     <string name="resume_scroll">還原滑動</string>
     <string name="uploading_image">上傳圖片中</string>
     <string name="settings">設定</string>
-    <string name="external_upload_disclaimer">多媒體檔案上傳由 https://nuuls.com/i 提供，請自行承擔風險</string>
-    <string name="external_upload_title">上傳自訂圖片</string>
+    <string name="nuuls_upload_disclaimer">多媒體檔案上傳由 %1$s 提供，請自行承擔風險</string>
+    <string name="nuuls_upload_title">上傳自訂圖片</string>
     <string name="snackbar_message_copied">已複製訊息</string>
     <string name="snackbar_error_copied">已複製錯誤訊息</string>
     <string name="notification_stop">停止</string>

--- a/app/src/main/res/values-b+zh+Hant+TW/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant+TW/strings.xml
@@ -29,7 +29,8 @@
     <string name="resume_scroll">還原滑動</string>
     <string name="uploading_image">上傳圖片中</string>
     <string name="settings">設定</string>
-    <string name="nuuls_upload_disclaimer">多媒體檔案上傳由 %1$s 提供，請自行承擔風險</string>
+    <string name="nuuls_upload_disclaimer">多媒體檔案上傳由 https://nuuls.com/i 提供，請自行承擔風險</string>
+    <string name="external_upload_disclaimer">多媒體檔案上傳由 %1$s 提供，請自行承擔風險</string>
     <string name="nuuls_upload_title">上傳自訂圖片</string>
     <string name="snackbar_message_copied">已複製訊息</string>
     <string name="snackbar_error_copied">已複製錯誤訊息</string>

--- a/app/src/main/res/values-b+zh+Hant+TW/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant+TW/strings.xml
@@ -29,8 +29,8 @@
     <string name="resume_scroll">還原滑動</string>
     <string name="uploading_image">上傳圖片中</string>
     <string name="settings">設定</string>
-    <string name="nuuls_upload_disclaimer">多媒體檔案上傳由 https://nuuls.com/i 提供，請自行承擔風險</string>
-    <string name="nuuls_upload_title">上傳自訂圖片</string>
+    <string name="external_upload_disclaimer">多媒體檔案上傳由 https://nuuls.com/i 提供，請自行承擔風險</string>
+    <string name="external_upload_title">上傳自訂圖片</string>
     <string name="snackbar_message_copied">已複製訊息</string>
     <string name="snackbar_error_copied">已複製錯誤訊息</string>
     <string name="notification_stop">停止</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -14,8 +14,8 @@
     <string name="choose_media">Triar media existent</string>
     <string name="hide_actionbar">Ocultar barra d\'eines</string>
     <string name="resume_scroll">Reanudar scroll</string>
-    <string name="nuuls_upload_disclaimer">Hosting extern proporcionat per https://nuuls.com/i, fes-lo servir sota el teu propi risc.</string>
-    <string name="nuuls_upload_title">Pujada de media personalitzat</string>
+    <string name="external_upload_disclaimer">Hosting extern proporcionat per https://nuuls.com/i, fes-lo servir sota el teu propi risc.</string>
+    <string name="external_upload_title">Pujada de media personalitzat</string>
     <string name="snackbar_error_copied">Error informació copiada</string>
     <string name="notification_title">FeelsDankMan</string>
     <string name="notification_message">DankChat obert en segon pla</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -14,8 +14,8 @@
     <string name="choose_media">Triar media existent</string>
     <string name="hide_actionbar">Ocultar barra d\'eines</string>
     <string name="resume_scroll">Reanudar scroll</string>
-    <string name="external_upload_disclaimer">Hosting extern proporcionat per https://nuuls.com/i, fes-lo servir sota el teu propi risc.</string>
-    <string name="external_upload_title">Pujada de media personalitzat</string>
+    <string name="nuuls_upload_disclaimer">Hosting extern proporcionat per %1$s, fes-lo servir sota el teu propi risc.</string>
+    <string name="nuuls_upload_title">Pujada de media personalitzat</string>
     <string name="snackbar_error_copied">Error informació copiada</string>
     <string name="notification_title">FeelsDankMan</string>
     <string name="notification_message">DankChat obert en segon pla</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -14,7 +14,8 @@
     <string name="choose_media">Triar media existent</string>
     <string name="hide_actionbar">Ocultar barra d\'eines</string>
     <string name="resume_scroll">Reanudar scroll</string>
-    <string name="nuuls_upload_disclaimer">Hosting extern proporcionat per %1$s, fes-lo servir sota el teu propi risc.</string>
+    <string name="nuuls_upload_disclaimer">Hosting extern proporcionat per https://nuuls.com/i, fes-lo servir sota el teu propi risc.</string>
+    <string name="external_upload_disclaimer">Hosting extern proporcionat per %1$s, fes-lo servir sota el teu propi risc.</string>
     <string name="nuuls_upload_title">Pujada de media personalitzat</string>
     <string name="snackbar_error_copied">Error informació copiada</string>
     <string name="notification_title">FeelsDankMan</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Obnovit posouvání chatu</string>
     <string name="uploading_image">Nahrávání souboru</string>
     <string name="settings">Nastavení</string>
-    <string name="nuuls_upload_disclaimer">Externí hostování poskytované %1$s ,používejte na vlastní riziko.</string>
+    <string name="nuuls_upload_disclaimer">Externí hostování poskytované https://nuuls.com/i ,používejte na vlastní riziko.</string>
+    <string name="external_upload_disclaimer">Externí hostování poskytované %1$s ,používejte na vlastní riziko.</string>
     <string name="nuuls_upload_title">Nahrání vlastního obrázku</string>
     <string name="snackbar_message_copied">Zpráva zkopírována</string>
     <string name="snackbar_error_copied">Informace o chybě zkopírovány</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Obnovit posouvání chatu</string>
     <string name="uploading_image">Nahrávání souboru</string>
     <string name="settings">Nastavení</string>
-    <string name="nuuls_upload_disclaimer">Externí hostování poskytované https://nuuls.com/i ,používejte na vlastní riziko.</string>
-    <string name="nuuls_upload_title">Nahrání vlastního obrázku</string>
+    <string name="external_upload_disclaimer">Externí hostování poskytované https://nuuls.com/i ,používejte na vlastní riziko.</string>
+    <string name="external_upload_title">Nahrání vlastního obrázku</string>
     <string name="snackbar_message_copied">Zpráva zkopírována</string>
     <string name="snackbar_error_copied">Informace o chybě zkopírovány</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Obnovit posouvání chatu</string>
     <string name="uploading_image">Nahrávání souboru</string>
     <string name="settings">Nastavení</string>
-    <string name="external_upload_disclaimer">Externí hostování poskytované https://nuuls.com/i ,používejte na vlastní riziko.</string>
-    <string name="external_upload_title">Nahrání vlastního obrázku</string>
+    <string name="nuuls_upload_disclaimer">Externí hostování poskytované %1$s ,používejte na vlastní riziko.</string>
+    <string name="nuuls_upload_title">Nahrání vlastního obrázku</string>
     <string name="snackbar_message_copied">Zpráva zkopírována</string>
     <string name="snackbar_error_copied">Informace o chybě zkopírovány</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Scrollen fortsetzen</string>
     <string name="uploading_image">Datei wird hochgeladen</string>
     <string name="settings">Einstellungen</string>
-    <string name="nuuls_upload_disclaimer">Medien werden auf https://nuuls.com/i gehostet. Benutzung auf eigene Gefahr</string>
-    <string name="nuuls_upload_title">Benutzerdefinierter Medienupload</string>
+    <string name="external_upload_disclaimer">Medien werden auf https://nuuls.com/i gehostet. Benutzung auf eigene Gefahr</string>
+    <string name="external_upload_title">Benutzerdefinierter Medienupload</string>
     <string name="snackbar_message_copied">Nachricht kopiert</string>
     <string name="snackbar_error_copied">Inhalt der Fehlernachricht kopiert</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Scrollen fortsetzen</string>
     <string name="uploading_image">Datei wird hochgeladen</string>
     <string name="settings">Einstellungen</string>
-    <string name="external_upload_disclaimer">Medien werden auf https://nuuls.com/i gehostet. Benutzung auf eigene Gefahr</string>
-    <string name="external_upload_title">Benutzerdefinierter Medienupload</string>
+    <string name="nuuls_upload_disclaimer">Medien werden auf %1$s gehostet. Benutzung auf eigene Gefahr</string>
+    <string name="nuuls_upload_title">Benutzerdefinierter Medienupload</string>
     <string name="snackbar_message_copied">Nachricht kopiert</string>
     <string name="snackbar_error_copied">Inhalt der Fehlernachricht kopiert</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Scrollen fortsetzen</string>
     <string name="uploading_image">Datei wird hochgeladen</string>
     <string name="settings">Einstellungen</string>
-    <string name="nuuls_upload_disclaimer">Medien werden auf %1$s gehostet. Benutzung auf eigene Gefahr</string>
+    <string name="nuuls_upload_disclaimer">Medien werden auf https://nuuls.com/i gehostet. Benutzung auf eigene Gefahr</string>
+    <string name="external_upload_disclaimer">Medien werden auf %1$s gehostet. Benutzung auf eigene Gefahr</string>
     <string name="nuuls_upload_title">Benutzerdefinierter Medienupload</string>
     <string name="snackbar_message_copied">Nachricht kopiert</string>
     <string name="snackbar_error_copied">Inhalt der Fehlernachricht kopiert</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="nuuls_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="nuuls_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
+    <string name="external_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
     <string name="nuuls_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="nuuls_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
-    <string name="nuuls_upload_title">Custom media upload</string>
+    <string name="external_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
+    <string name="external_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="external_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
-    <string name="external_upload_title">Custom media upload</string>
+    <string name="nuuls_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="nuuls_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="nuuls_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="nuuls_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
+    <string name="external_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
     <string name="nuuls_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="nuuls_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
-    <string name="nuuls_upload_title">Custom media upload</string>
+    <string name="external_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
+    <string name="external_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="external_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
-    <string name="external_upload_title">Custom media upload</string>
+    <string name="nuuls_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="nuuls_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Reanudar desplazamiento</string>
     <string name="uploading_image">Subiendo imagen</string>
     <string name="settings">Ajustes</string>
-    <string name="nuuls_upload_disclaimer">Hosting externo proporcionado por https://nuuls.com/i, utilízalo bajo tu propio riesgo.</string>
-    <string name="nuuls_upload_title">Subida de imagen personalizada</string>
+    <string name="external_upload_disclaimer">Hosting externo proporcionado por https://nuuls.com/i, utilízalo bajo tu propio riesgo.</string>
+    <string name="external_upload_title">Subida de imagen personalizada</string>
     <string name="snackbar_message_copied">Mensaje copiado</string>
     <string name="snackbar_error_copied">Error al copiar</string>
     <string name="notification_stop">Parar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Reanudar desplazamiento</string>
     <string name="uploading_image">Subiendo imagen</string>
     <string name="settings">Ajustes</string>
-    <string name="external_upload_disclaimer">Hosting externo proporcionado por https://nuuls.com/i, utilízalo bajo tu propio riesgo.</string>
-    <string name="external_upload_title">Subida de imagen personalizada</string>
+    <string name="nuuls_upload_disclaimer">Hosting externo proporcionado por %1$s, utilízalo bajo tu propio riesgo.</string>
+    <string name="nuuls_upload_title">Subida de imagen personalizada</string>
     <string name="snackbar_message_copied">Mensaje copiado</string>
     <string name="snackbar_error_copied">Error al copiar</string>
     <string name="notification_stop">Parar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Reanudar desplazamiento</string>
     <string name="uploading_image">Subiendo imagen</string>
     <string name="settings">Ajustes</string>
-    <string name="nuuls_upload_disclaimer">Hosting externo proporcionado por %1$s, utilízalo bajo tu propio riesgo.</string>
+    <string name="nuuls_upload_disclaimer">Hosting externo proporcionado por https://nuuls.com/i, utilízalo bajo tu propio riesgo.</string>
+    <string name="external_upload_disclaimer">Hosting externo proporcionado por %1$s, utilízalo bajo tu propio riesgo.</string>
     <string name="nuuls_upload_title">Subida de imagen personalizada</string>
     <string name="snackbar_message_copied">Mensaje copiado</string>
     <string name="snackbar_error_copied">Error al copiar</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -34,6 +34,7 @@
     <string name="resume_scroll">از سر گرفتن چرخش</string>
     <string name="uploading_image">در حال بارگذاری پرونده</string>
     <string name="settings">تنظیمات</string>
-    <string name="nuuls_upload_disclaimer">میزبانی خارجی ارائه شده توسط %1$s، با مسئولیت خودتان استفاده کنید.</string>
+    <string name="nuuls_upload_disclaimer">میزبانی خارجی ارائه شده توسط https://nuuls.com/i، با مسئولیت خودتان استفاده کنید.</string>
+    <string name="external_upload_disclaimer">میزبانی خارجی ارائه شده توسط %1$s، با مسئولیت خودتان استفاده کنید.</string>
     <string name="nuuls_upload_title">بارگذاری رسانه های سفارشی</string>
 </resources>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -34,6 +34,6 @@
     <string name="resume_scroll">از سر گرفتن چرخش</string>
     <string name="uploading_image">در حال بارگذاری پرونده</string>
     <string name="settings">تنظیمات</string>
-    <string name="external_upload_disclaimer">میزبانی خارجی ارائه شده توسط https://nuuls.com/i، با مسئولیت خودتان استفاده کنید.</string>
-    <string name="external_upload_title">بارگذاری رسانه های سفارشی</string>
+    <string name="nuuls_upload_disclaimer">میزبانی خارجی ارائه شده توسط %1$s، با مسئولیت خودتان استفاده کنید.</string>
+    <string name="nuuls_upload_title">بارگذاری رسانه های سفارشی</string>
 </resources>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -34,6 +34,6 @@
     <string name="resume_scroll">از سر گرفتن چرخش</string>
     <string name="uploading_image">در حال بارگذاری پرونده</string>
     <string name="settings">تنظیمات</string>
-    <string name="nuuls_upload_disclaimer">میزبانی خارجی ارائه شده توسط https://nuuls.com/i، با مسئولیت خودتان استفاده کنید.</string>
-    <string name="nuuls_upload_title">بارگذاری رسانه های سفارشی</string>
+    <string name="external_upload_disclaimer">میزبانی خارجی ارائه شده توسط https://nuuls.com/i، با مسئولیت خودتان استفاده کنید.</string>
+    <string name="external_upload_title">بارگذاری رسانه های سفارشی</string>
 </resources>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -28,7 +28,8 @@
     <string name="hide_actionbar">Piilota työkalurivi</string>
     <string name="resume_scroll">Jatka vieritystä</string>
     <string name="settings">Asetukset</string>
-    <string name="nuuls_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa %1$s, käytä omalla vastuullasi.</string>
+    <string name="nuuls_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa https://nuuls.com/i, käytä omalla vastuullasi.</string>
+    <string name="external_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa %1$s, käytä omalla vastuullasi.</string>
     <string name="nuuls_upload_title">Mukautettu kuvan lataus</string>
     <string name="snackbar_message_copied">Viesti kopioitu</string>
     <string name="snackbar_error_copied">Virhetiedot kopioitu</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -28,8 +28,8 @@
     <string name="hide_actionbar">Piilota työkalurivi</string>
     <string name="resume_scroll">Jatka vieritystä</string>
     <string name="settings">Asetukset</string>
-    <string name="external_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa https://nuuls.com/i, käytä omalla vastuullasi.</string>
-    <string name="external_upload_title">Mukautettu kuvan lataus</string>
+    <string name="nuuls_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa %1$s, käytä omalla vastuullasi.</string>
+    <string name="nuuls_upload_title">Mukautettu kuvan lataus</string>
     <string name="snackbar_message_copied">Viesti kopioitu</string>
     <string name="snackbar_error_copied">Virhetiedot kopioitu</string>
     <string name="notification_stop">Pysäytä</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -28,8 +28,8 @@
     <string name="hide_actionbar">Piilota työkalurivi</string>
     <string name="resume_scroll">Jatka vieritystä</string>
     <string name="settings">Asetukset</string>
-    <string name="nuuls_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa https://nuuls.com/i, käytä omalla vastuullasi.</string>
-    <string name="nuuls_upload_title">Mukautettu kuvan lataus</string>
+    <string name="external_upload_disclaimer">Kolmannen osapuolen ylläpidon tarjoaa https://nuuls.com/i, käytä omalla vastuullasi.</string>
+    <string name="external_upload_title">Mukautettu kuvan lataus</string>
     <string name="snackbar_message_copied">Viesti kopioitu</string>
     <string name="snackbar_error_copied">Virhetiedot kopioitu</string>
     <string name="notification_stop">Pysäytä</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -28,8 +28,8 @@
     <string name="resume_scroll">Réactiver le défilement</string>
     <string name="uploading_image">Envoi de l\'image</string>
     <string name="settings">Réglages</string>
-    <string name="external_upload_disclaimer">Stockage fourni par https://nuuls.com/i, à vos risques et périls.</string>
-    <string name="external_upload_title">Envoi d\'une image personalisée</string>
+    <string name="nuuls_upload_disclaimer">Stockage fourni par %1$s, à vos risques et périls.</string>
+    <string name="nuuls_upload_title">Envoi d\'une image personalisée</string>
     <string name="snackbar_message_copied">Message copié</string>
     <string name="snackbar_error_copied">Info sur l\'erreur copiée</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -28,7 +28,8 @@
     <string name="resume_scroll">Réactiver le défilement</string>
     <string name="uploading_image">Envoi de l\'image</string>
     <string name="settings">Réglages</string>
-    <string name="nuuls_upload_disclaimer">Stockage fourni par %1$s, à vos risques et périls.</string>
+    <string name="nuuls_upload_disclaimer">Stockage fourni par https://nuuls.com/i, à vos risques et périls.</string>
+    <string name="external_upload_disclaimer">Stockage fourni par %1$s, à vos risques et périls.</string>
     <string name="nuuls_upload_title">Envoi d\'une image personalisée</string>
     <string name="snackbar_message_copied">Message copié</string>
     <string name="snackbar_error_copied">Info sur l\'erreur copiée</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -28,8 +28,8 @@
     <string name="resume_scroll">Réactiver le défilement</string>
     <string name="uploading_image">Envoi de l\'image</string>
     <string name="settings">Réglages</string>
-    <string name="nuuls_upload_disclaimer">Stockage fourni par https://nuuls.com/i, à vos risques et périls.</string>
-    <string name="nuuls_upload_title">Envoi d\'une image personalisée</string>
+    <string name="external_upload_disclaimer">Stockage fourni par https://nuuls.com/i, à vos risques et périls.</string>
+    <string name="external_upload_title">Envoi d\'une image personalisée</string>
     <string name="snackbar_message_copied">Message copié</string>
     <string name="snackbar_error_copied">Info sur l\'erreur copiée</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,7 +27,8 @@
     <string name="resume_scroll">Riprendi scorrimento</string>
     <string name="uploading_image">Caricando un\'immagine</string>
     <string name="settings">Impostazioni</string>
-    <string name="nuuls_upload_disclaimer">Hosting esterno fornito da %1$s, a vostro rischio e pericolo</string>
+    <string name="nuuls_upload_disclaimer">Hosting esterno fornito da https://nuuls.com/i, a vostro rischio e pericolo</string>
+    <string name="external_upload_disclaimer">Hosting esterno fornito da %1$s, a vostro rischio e pericolo</string>
     <string name="nuuls_upload_title">Caricatore di immagini personalizzato</string>
     <string name="snackbar_message_copied">Messaggio copiato</string>
     <string name="snackbar_error_copied">Informazione d\'errore copiata</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,8 +27,8 @@
     <string name="resume_scroll">Riprendi scorrimento</string>
     <string name="uploading_image">Caricando un\'immagine</string>
     <string name="settings">Impostazioni</string>
-    <string name="external_upload_disclaimer">Hosting esterno fornito da https://nuuls.com/i, a vostro rischio e pericolo</string>
-    <string name="external_upload_title">Caricatore di immagini personalizzato</string>
+    <string name="nuuls_upload_disclaimer">Hosting esterno fornito da %1$s, a vostro rischio e pericolo</string>
+    <string name="nuuls_upload_title">Caricatore di immagini personalizzato</string>
     <string name="snackbar_message_copied">Messaggio copiato</string>
     <string name="snackbar_error_copied">Informazione d\'errore copiata</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,8 +27,8 @@
     <string name="resume_scroll">Riprendi scorrimento</string>
     <string name="uploading_image">Caricando un\'immagine</string>
     <string name="settings">Impostazioni</string>
-    <string name="nuuls_upload_disclaimer">Hosting esterno fornito da https://nuuls.com/i, a vostro rischio e pericolo</string>
-    <string name="nuuls_upload_title">Caricatore di immagini personalizzato</string>
+    <string name="external_upload_disclaimer">Hosting esterno fornito da https://nuuls.com/i, a vostro rischio e pericolo</string>
+    <string name="external_upload_title">Caricatore di immagini personalizzato</string>
     <string name="snackbar_message_copied">Messaggio copiato</string>
     <string name="snackbar_error_copied">Informazione d\'errore copiata</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Wznów przewijanie</string>
     <string name="uploading_image">Prześlij zdjęcie</string>
     <string name="settings">Ustawienia</string>
-    <string name="nuuls_upload_disclaimer">Zewnętrzny hosting dostarczony przez https://nuuls.com/i, używaj na własną odpowiedzialność.</string>
-    <string name="nuuls_upload_title">Niestandardowe przesyłanie plików</string>
+    <string name="external_upload_disclaimer">Zewnętrzny hosting dostarczony przez https://nuuls.com/i, używaj na własną odpowiedzialność.</string>
+    <string name="external_upload_title">Niestandardowe przesyłanie plików</string>
     <string name="snackbar_message_copied">Skopiowano wiadomość</string>
     <string name="snackbar_error_copied">Skopiowano wiadomość błędu</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Wznów przewijanie</string>
     <string name="uploading_image">Prześlij zdjęcie</string>
     <string name="settings">Ustawienia</string>
-    <string name="external_upload_disclaimer">Zewnętrzny hosting dostarczony przez https://nuuls.com/i, używaj na własną odpowiedzialność.</string>
-    <string name="external_upload_title">Niestandardowe przesyłanie plików</string>
+    <string name="nuuls_upload_disclaimer">Zewnętrzny hosting dostarczony przez %1$s, używaj na własną odpowiedzialność.</string>
+    <string name="nuuls_upload_title">Niestandardowe przesyłanie plików</string>
     <string name="snackbar_message_copied">Skopiowano wiadomość</string>
     <string name="snackbar_error_copied">Skopiowano wiadomość błędu</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Wznów przewijanie</string>
     <string name="uploading_image">Prześlij zdjęcie</string>
     <string name="settings">Ustawienia</string>
-    <string name="nuuls_upload_disclaimer">Zewnętrzny hosting dostarczony przez %1$s, używaj na własną odpowiedzialność.</string>
+    <string name="nuuls_upload_disclaimer">Zewnętrzny hosting dostarczony przez https://nuuls.com/i, używaj na własną odpowiedzialność.</string>
+    <string name="external_upload_disclaimer">Zewnętrzny hosting dostarczony przez %1$s, używaj na własną odpowiedzialność.</string>
     <string name="nuuls_upload_title">Niestandardowe przesyłanie plików</string>
     <string name="snackbar_message_copied">Skopiowano wiadomość</string>
     <string name="snackbar_error_copied">Skopiowano wiadomość błędu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Continuar rolagem</string>
     <string name="uploading_image">Enviando arquivo</string>
     <string name="settings">Configurações</string>
-    <string name="external_upload_disclaimer">Hospedagem externa fornecida por https://nuuls.com/i, use por sua conta e risco.</string>
-    <string name="external_upload_title">Envio de mídia personalizado</string>
+    <string name="nuuls_upload_disclaimer">Hospedagem externa fornecida por %1$s, use por sua conta e risco.</string>
+    <string name="nuuls_upload_title">Envio de mídia personalizado</string>
     <string name="snackbar_message_copied">Mensagem copiada</string>
     <string name="snackbar_error_copied">Informação de erro copiada</string>
     <string name="notification_stop">Parar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Continuar rolagem</string>
     <string name="uploading_image">Enviando arquivo</string>
     <string name="settings">Configurações</string>
-    <string name="nuuls_upload_disclaimer">Hospedagem externa fornecida por https://nuuls.com/i, use por sua conta e risco.</string>
-    <string name="nuuls_upload_title">Envio de mídia personalizado</string>
+    <string name="external_upload_disclaimer">Hospedagem externa fornecida por https://nuuls.com/i, use por sua conta e risco.</string>
+    <string name="external_upload_title">Envio de mídia personalizado</string>
     <string name="snackbar_message_copied">Mensagem copiada</string>
     <string name="snackbar_error_copied">Informação de erro copiada</string>
     <string name="notification_stop">Parar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Continuar rolagem</string>
     <string name="uploading_image">Enviando arquivo</string>
     <string name="settings">Configurações</string>
-    <string name="nuuls_upload_disclaimer">Hospedagem externa fornecida por %1$s, use por sua conta e risco.</string>
+    <string name="nuuls_upload_disclaimer">Hospedagem externa fornecida por https://nuuls.com/i, use por sua conta e risco.</string>
+    <string name="external_upload_disclaimer">Hospedagem externa fornecida por %1$s, use por sua conta e risco.</string>
     <string name="nuuls_upload_title">Envio de mídia personalizado</string>
     <string name="snackbar_message_copied">Mensagem copiada</string>
     <string name="snackbar_error_copied">Informação de erro copiada</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Возобновить прокрутку</string>
     <string name="uploading_image">Загружается файл</string>
     <string name="settings">Настройки</string>
-    <string name="nuuls_upload_disclaimer">Сторонний хостинг предоставлен %1$s, используйте на ваше усмотрение.</string>
+    <string name="nuuls_upload_disclaimer">Сторонний хостинг предоставлен https://nuuls.com/i, используйте на ваше усмотрение.</string>
+    <string name="external_upload_disclaimer">Сторонний хостинг предоставлен %1$s, используйте на ваше усмотрение.</string>
     <string name="nuuls_upload_title">Загрузка собственного изображения</string>
     <string name="snackbar_message_copied">Сообщение скопировано</string>
     <string name="snackbar_error_copied">Информация об ошибке скопирована</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Возобновить прокрутку</string>
     <string name="uploading_image">Загружается файл</string>
     <string name="settings">Настройки</string>
-    <string name="nuuls_upload_disclaimer">Сторонний хостинг предоставлен https://nuuls.com/i, используйте на ваше усмотрение.</string>
-    <string name="nuuls_upload_title">Загрузка собственного изображения</string>
+    <string name="external_upload_disclaimer">Сторонний хостинг предоставлен https://nuuls.com/i, используйте на ваше усмотрение.</string>
+    <string name="external_upload_title">Загрузка собственного изображения</string>
     <string name="snackbar_message_copied">Сообщение скопировано</string>
     <string name="snackbar_error_copied">Информация об ошибке скопирована</string>
     <string name="notification_stop">Стоп</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Возобновить прокрутку</string>
     <string name="uploading_image">Загружается файл</string>
     <string name="settings">Настройки</string>
-    <string name="external_upload_disclaimer">Сторонний хостинг предоставлен https://nuuls.com/i, используйте на ваше усмотрение.</string>
-    <string name="external_upload_title">Загрузка собственного изображения</string>
+    <string name="nuuls_upload_disclaimer">Сторонний хостинг предоставлен %1$s, используйте на ваше усмотрение.</string>
+    <string name="nuuls_upload_title">Загрузка собственного изображения</string>
     <string name="snackbar_message_copied">Сообщение скопировано</string>
     <string name="snackbar_error_copied">Информация об ошибке скопирована</string>
     <string name="notification_stop">Стоп</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -29,7 +29,8 @@
     <string name="resume_scroll">Nastavi skrolovanje</string>
     <string name="uploading_image">Slika se šalje</string>
     <string name="settings">Podešavanja</string>
-    <string name="nuuls_upload_disclaimer">Spoljašni hosting pruža %1$s, korisite ga na sopstveni rizik</string>
+    <string name="nuuls_upload_disclaimer">Spoljašni hosting pruža https://nuuls.com/i, korisite ga na sopstveni rizik</string>
+    <string name="external_upload_disclaimer">Spoljašni hosting pruža %1$s, korisite ga na sopstveni rizik</string>
     <string name="nuuls_upload_title">Prilagođeno slanje slika</string>
     <string name="snackbar_message_copied">Poruka kopirana</string>
     <string name="snackbar_error_copied">Informacije o grešci kopirane</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -29,8 +29,8 @@
     <string name="resume_scroll">Nastavi skrolovanje</string>
     <string name="uploading_image">Slika se šalje</string>
     <string name="settings">Podešavanja</string>
-    <string name="external_upload_disclaimer">Spoljašni hosting pruža https://nuuls.com/i, korisite ga na sopstveni rizik</string>
-    <string name="external_upload_title">Prilagođeno slanje slika</string>
+    <string name="nuuls_upload_disclaimer">Spoljašni hosting pruža %1$s, korisite ga na sopstveni rizik</string>
+    <string name="nuuls_upload_title">Prilagođeno slanje slika</string>
     <string name="snackbar_message_copied">Poruka kopirana</string>
     <string name="snackbar_error_copied">Informacije o grešci kopirane</string>
     <string name="notification_stop">Stani</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -29,8 +29,8 @@
     <string name="resume_scroll">Nastavi skrolovanje</string>
     <string name="uploading_image">Slika se šalje</string>
     <string name="settings">Podešavanja</string>
-    <string name="nuuls_upload_disclaimer">Spoljašni hosting pruža https://nuuls.com/i, korisite ga na sopstveni rizik</string>
-    <string name="nuuls_upload_title">Prilagođeno slanje slika</string>
+    <string name="external_upload_disclaimer">Spoljašni hosting pruža https://nuuls.com/i, korisite ga na sopstveni rizik</string>
+    <string name="external_upload_title">Prilagođeno slanje slika</string>
     <string name="snackbar_message_copied">Poruka kopirana</string>
     <string name="snackbar_error_copied">Informacije o grešci kopirane</string>
     <string name="notification_stop">Stani</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Kaydırmaya devam et</string>
     <string name="uploading_image">Resim yükleniyor</string>
     <string name="settings">Ayarlar</string>
-    <string name="nuuls_upload_disclaimer">Dış barındırma https://nuuls.com/i tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
-    <string name="nuuls_upload_title">Özel resim yükleme</string>
+    <string name="external_upload_disclaimer">Dış barındırma https://nuuls.com/i tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
+    <string name="external_upload_title">Özel resim yükleme</string>
     <string name="snackbar_message_copied">Mesaj kopyalandı</string>
     <string name="snackbar_error_copied">Hata bilgisi kopyalandı</string>
     <string name="notification_stop">Durdur</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Kaydırmaya devam et</string>
     <string name="uploading_image">Resim yükleniyor</string>
     <string name="settings">Ayarlar</string>
-    <string name="nuuls_upload_disclaimer">Dış barındırma %1$s tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
+    <string name="nuuls_upload_disclaimer">Dış barındırma https://nuuls.com/i tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
+    <string name="external_upload_disclaimer">Dış barındırma %1$s tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
     <string name="nuuls_upload_title">Özel resim yükleme</string>
     <string name="snackbar_message_copied">Mesaj kopyalandı</string>
     <string name="snackbar_error_copied">Hata bilgisi kopyalandı</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Kaydırmaya devam et</string>
     <string name="uploading_image">Resim yükleniyor</string>
     <string name="settings">Ayarlar</string>
-    <string name="external_upload_disclaimer">Dış barındırma https://nuuls.com/i tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
-    <string name="external_upload_title">Özel resim yükleme</string>
+    <string name="nuuls_upload_disclaimer">Dış barındırma %1$s tarafından sağlanmaktadır, kendi sorumluluğunuzda kullanınız.</string>
+    <string name="nuuls_upload_title">Özel resim yükleme</string>
     <string name="snackbar_message_copied">Mesaj kopyalandı</string>
     <string name="snackbar_error_copied">Hata bilgisi kopyalandı</string>
     <string name="notification_stop">Durdur</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Відновити прокручування</string>
     <string name="uploading_image">Файл завантажується</string>
     <string name="settings">Налаштування</string>
-    <string name="nuuls_upload_disclaimer">Зовнішній хостинг надано https://nuuls.com/i. Використовуйте на Ваш розсуд.</string>
-    <string name="nuuls_upload_title">Завантаження власного зображення</string>
+    <string name="external_upload_disclaimer">Зовнішній хостинг надано https://nuuls.com/i. Використовуйте на Ваш розсуд.</string>
+    <string name="external_upload_title">Завантаження власного зображення</string>
     <string name="snackbar_message_copied">Повідомлення скопійовано</string>
     <string name="snackbar_error_copied">Інформацію про помилку скопійовано</string>
     <string name="notification_stop">Стоп</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -34,7 +34,8 @@
     <string name="resume_scroll">Відновити прокручування</string>
     <string name="uploading_image">Файл завантажується</string>
     <string name="settings">Налаштування</string>
-    <string name="nuuls_upload_disclaimer">Зовнішній хостинг надано %1$s. Використовуйте на Ваш розсуд.</string>
+    <string name="nuuls_upload_disclaimer">Зовнішній хостинг надано https://nuuls.com/i. Використовуйте на Ваш розсуд.</string>
+    <string name="external_upload_disclaimer">Зовнішній хостинг надано %1$s. Використовуйте на Ваш розсуд.</string>
     <string name="nuuls_upload_title">Завантаження власного зображення</string>
     <string name="snackbar_message_copied">Повідомлення скопійовано</string>
     <string name="snackbar_error_copied">Інформацію про помилку скопійовано</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Відновити прокручування</string>
     <string name="uploading_image">Файл завантажується</string>
     <string name="settings">Налаштування</string>
-    <string name="external_upload_disclaimer">Зовнішній хостинг надано https://nuuls.com/i. Використовуйте на Ваш розсуд.</string>
-    <string name="external_upload_title">Завантаження власного зображення</string>
+    <string name="nuuls_upload_disclaimer">Зовнішній хостинг надано %1$s. Використовуйте на Ваш розсуд.</string>
+    <string name="nuuls_upload_title">Завантаження власного зображення</string>
     <string name="snackbar_message_copied">Повідомлення скопійовано</string>
     <string name="snackbar_error_copied">Інформацію про помилку скопійовано</string>
     <string name="notification_stop">Стоп</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="nuuls_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
-    <string name="nuuls_upload_title">Custom media upload</string>
+    <string name="external_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="external_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,8 +34,8 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <!-- the external hosting is called "nuuls" for historical reasons -->
-    <string name="nuuls_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="nuuls_upload_disclaimer">External hosting provided by https://nuuls.com/i, use at your own risk.</string>
+    <string name="external_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
     <string name="nuuls_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,8 +329,6 @@
     <string name="preference_retain_webview_key" translatable="false">retain_webview_key</string>
     <string name="preference_retain_webview_title">Prevent stream reloads</string>
     <string name="preference_retain_webview_summary">Enables experimental prevention of stream reloads after orientation changes or re-opening DankChat.</string>
-    <string name="invalid_media_url_title">Invalid Media Uploader Configuration</string>
-    <string name="invalid_media_url_message">Your Upload URL (%1$s) appears to be invalid, configure it correctly to use this feature.</string>
     <string name="reset_media_uploader_dialog_title">Reset Media Uploader Settings</string>
     <string name="reset_media_uploader_dialog_message">Are you sure you want to reset the media uploader settings to default?</string>
     <string name="reset_media_uploader_dialog_positive">Reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,6 +328,8 @@
     <string name="preference_retain_webview_key" translatable="false">retain_webview_key</string>
     <string name="preference_retain_webview_title">Prevent stream reloads</string>
     <string name="preference_retain_webview_summary">Enables experimental prevention of stream reloads after orientation changes or re-opening DankChat.</string>
+    <string name="invalid_media_url_title">Invalid Media Uploader Configuration</string>
+    <string name="invalid_media_url_message">Your Upload URL (%1$s) appears to be invalid, configure it correctly to use this feature.</string>
     <plurals name="viewers">
         <item quantity="one">Live with %d viewer</item>
         <item quantity="other">Live with %d viewers</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,8 +34,9 @@
     <string name="resume_scroll">Resume scroll</string>
     <string name="uploading_image">Uploading file</string>
     <string name="settings">Settings</string>
-    <string name="external_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
-    <string name="external_upload_title">Custom media upload</string>
+    <!-- the external hosting is called "nuuls" for historical reasons -->
+    <string name="nuuls_upload_disclaimer">External hosting provided by %1$s, use at your own risk.</string>
+    <string name="nuuls_upload_title">Custom media upload</string>
     <string name="snackbar_message_copied">Message copied</string>
     <string name="snackbar_error_copied">Error information copied</string>
     <string name="notification_stop">Stop</string>


### PR DESCRIPTION
Fix #298 

Feature:
- show hostname of the custom upload URL instead of `https://i.nuuls.com`
- (bonus) validate configured URL when clicking upload media

