### PR TITLE
Fix disabled user display entries getting applied, improve ux

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/UserDisplay.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/UserDisplay.kt
@@ -7,8 +7,8 @@ import com.flxrs.dankchat.data.database.entity.UserDisplayEntity
 data class UserDisplay(val alias: String?, val color: Int?)
 
 fun UserDisplayEntity.toUserDisplay() = UserDisplay(
-    alias = alias?.takeIf { aliasEnabled && it.isNotBlank() },
-    color = color.takeIf { colorEnabled },
+    alias = alias?.takeIf { enabled && aliasEnabled && it.isNotBlank() },
+    color = color.takeIf { enabled && colorEnabled },
 )
 
 @ColorInt

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/userdisplay/UserDisplayAdapter.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/userdisplay/UserDisplayAdapter.kt
@@ -1,5 +1,6 @@
 package com.flxrs.dankchat.preferences.ui.userdisplay
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -41,16 +42,27 @@ class UserDisplayAdapter(
                         }.show()
                 }
 
+                userDisplayEnable.setOnCheckedChangeListener { _, checked ->
+                    val item = userDisplay ?: return@setOnCheckedChangeListener
+                    item.enabled = checked
+                    userDisplayEnableAlias.isEnabled = checked
+                    userDisplayEnableColor.isEnabled = checked
+
+                    userDisplayPickColorButton.isEnabled = checked && item.colorEnabled
+                    userDisplayAliasInput.isEnabled = checked && item.aliasEnabled
+                }
+
                 userDisplayEnableColor.setOnCheckedChangeListener { _, checked ->
                     val item = userDisplay ?: return@setOnCheckedChangeListener
                     item.colorEnabled = checked
-                    userDisplayPickColorButton.isEnabled = checked
+
+                    userDisplayPickColorButton.isEnabled = item.enabled && checked
                 }
 
                 userDisplayEnableAlias.setOnCheckedChangeListener { _, checked ->
                     val item = userDisplay ?: return@setOnCheckedChangeListener
                     item.aliasEnabled = checked
-                    userDisplayAliasInput.isEnabled = checked
+                    userDisplayAliasInput.isEnabled = item.enabled && checked
                 }
             }
         }
@@ -82,12 +94,20 @@ class UserDisplayAdapter(
             is EntryViewHolder -> {
                 val entry = currentList[position] as UserDisplayItem.Entry
                 with(holder.binding) {
+                    Log.i("Doge", "bind handler: $entry")
                     userDisplay = entry
+                    // enable checkbox handler
+                    userDisplayEnable.isChecked = entry.enabled
+                    userDisplayEnableColor.isEnabled = entry.enabled
+                    userDisplayEnableAlias.isEnabled = entry.enabled
+                    // colorEnable checkbox handler
                     userDisplayEnableColor.isChecked = entry.colorEnabled
-                    userDisplayPickColorButton.isEnabled = entry.colorEnabled
-                    userDisplayEnableAlias.isChecked = entry.aliasEnabled
-                    userDisplayAliasInput.isEnabled = entry.aliasEnabled
+                    userDisplayPickColorButton.isEnabled = entry.enabled && entry.colorEnabled
                     userDisplayPickColorButton.updateTextAndTextColor(entry)
+                    // aliasEnable checkbox handler
+                    userDisplayEnableAlias.isChecked = entry.aliasEnabled
+                    userDisplayAliasInput.isEnabled = entry.enabled && entry.aliasEnabled
+
                 }
             }
         }

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/userdisplay/UserDisplayAdapter.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/ui/userdisplay/UserDisplayAdapter.kt
@@ -1,6 +1,5 @@
 package com.flxrs.dankchat.preferences.ui.userdisplay
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -94,7 +93,6 @@ class UserDisplayAdapter(
             is EntryViewHolder -> {
                 val entry = currentList[position] as UserDisplayItem.Entry
                 with(holder.binding) {
-                    Log.i("Doge", "bind handler: $entry")
                     userDisplay = entry
                     // enable checkbox handler
                     userDisplayEnable.isChecked = entry.enabled

--- a/app/src/main/res/layout/user_display_item.xml
+++ b/app/src/main/res/layout/user_display_item.xml
@@ -58,7 +58,7 @@
                 android:id="@+id/flow_color_row"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="user_display_enable,user_display_enable_color,user_display_enable_alias"
+                app:constraint_referenced_ids="user_display_enable,user_display_enable_alias,user_display_enable_color"
                 app:flow_horizontalBias="0"
                 app:flow_horizontalStyle="packed"
                 app:flow_wrapMode="chain"

--- a/app/src/main/res/layout/user_display_item.xml
+++ b/app/src/main/res/layout/user_display_item.xml
@@ -72,7 +72,6 @@
                 style="@style/Widget.Material3.CompoundButton.CheckBox"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:checked="@={userDisplay.enabled}"
                 android:text="@string/enabled" />
 
             <com.google.android.material.checkbox.MaterialCheckBox


### PR DESCRIPTION
### Bug Description:

When user display is disabled (un-check the "Enabled") checkbox, the color or alias is still applied (if `Custom Alias` or `Custom Color` is checked). The correct behavior would be disable color/alias regardless of `Custom Alias` or `Custom Color`.


Video (by Twitch `@Photon_Gilbert`):

Notice how the custom color still apply if disabled until the `Custom Color` is also unchecked.
- https://photongilbert.s-ul.eu/fwjQ1w3n

### UX Improvement 
- disable all controls if the `Enabled` checkbox is unchecked. It wouldn't make sense to try enabling alias or color if whole entry is disabled.

- swap the position of `Custom Color` and `Custom Alias` to make the order of checkbox consistent with the order of input/button below.
   - before:  
![QOL-checkbox-before](https://user-images.githubusercontent.com/26536811/214084740-280c6222-52d2-4cdf-933f-baa50fb8d70e.png)
   - after: 
![QOL-checkbox-after](https://user-images.githubusercontent.com/26536811/214084778-2e6d3e1a-126f-4947-9f57-2874f7a2464b.png)

Small video to show how the controls will be disabled if the `Enabled` checkbox is unchecked.

https://kappa.lol/5jmXG



