### PR TITLE
Add stream uptime to stream information 

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/command/CommandRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/command/CommandRepository.kt
@@ -16,6 +16,7 @@ import com.flxrs.dankchat.data.twitch.message.WhisperMessage
 import com.flxrs.dankchat.di.ApplicationScope
 import com.flxrs.dankchat.preferences.DankChatPreferenceStore
 import com.flxrs.dankchat.preferences.command.CommandItem
+import com.flxrs.dankchat.utils.DateTimeUtils.calculateUptime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -28,13 +29,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.system.measureTimeMillis
-import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class CommandRepository @Inject constructor(
@@ -240,18 +237,7 @@ class CommandRepository @Inject constructor(
             .getOrNull()
             ?.getOrNull(0) ?: return CommandResult.AcceptedWithResponse("Channel is not live.")
 
-        val startedAt = Instant.parse(result.startedAt).atZone(ZoneId.systemDefault()).toEpochSecond()
-        val now = ZonedDateTime.now().toEpochSecond()
-
-        val duration = now.seconds - startedAt.seconds
-        val uptime = duration.toComponents { days, hours, minutes, _, _ ->
-            buildString {
-                if (days > 0) append("${days}d ")
-                if (hours > 0) append("${hours}h ")
-                append("${minutes}m")
-            }
-        }
-
+        val uptime = calculateUptime(result.startedAt)
         return CommandResult.AcceptedWithResponse("Uptime: $uptime")
     }
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
@@ -77,11 +77,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import java.io.File
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import java.util.*
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
@@ -679,18 +674,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             fetchTimerJob = timer(STREAM_REFRESH_RATE) {
                 val data = dataRepository.getStreams(channels)?.map {
-                    // Calculate uptime
-                    val startedAt = Instant.parse(it.startedAt).atZone(ZoneId.systemDefault()).toEpochSecond()
-                    val now = ZonedDateTime.now().toEpochSecond()
-                    val duration = now.seconds - startedAt.seconds
-                    val uptime = duration.toComponents { days, hours, minutes, _, _ ->
-                        buildString {
-                            if (days > 0) append("${days}d ")
-                            if (hours > 0) append("${hours}h ")
-                            append("${minutes}m")
-                        }
-                    }
-
+                    val uptime = DateTimeUtils.calculateUptime(it.startedAt)
                     val formatted = dankChatPreferenceStore.formatViewersString(it.viewerCount, uptime)
 
                     StreamData(channel = it.userLogin, formattedData = formatted)

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
@@ -77,6 +77,9 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import java.io.File
+import java.time.Duration
+import java.time.Instant
+import java.util.*
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
@@ -674,7 +677,17 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             fetchTimerJob = timer(STREAM_REFRESH_RATE) {
                 val data = dataRepository.getStreams(channels)?.map {
-                    val formatted = dankChatPreferenceStore.formatViewersString(it.viewerCount)
+                    var formatted = dankChatPreferenceStore.formatViewersString(it.viewerCount)
+
+                    try {
+                        // Try to calculate and show stream uptime
+                        val now = Date()
+                        val started = Instant.parse(it.startedAt)
+                        val difference = Duration.between(started, now.toInstant())
+                        val seconds = difference.seconds
+                        formatted += " for ${seconds / 3600}h ${(seconds % 3600) / 60}m"
+                    } catch(e: Exception) {}
+
                     StreamData(channel = it.userLogin, formattedData = formatted)
                 }.orEmpty()
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/main/MainViewModel.kt
@@ -679,23 +679,19 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             fetchTimerJob = timer(STREAM_REFRESH_RATE) {
                 val data = dataRepository.getStreams(channels)?.map {
-                    var formatted = dankChatPreferenceStore.formatViewersString(it.viewerCount)
-
-                    try {
-                        // Try to calculate and show stream uptime
-                        val startedAt = Instant.parse(it.startedAt).atZone(ZoneId.systemDefault()).toEpochSecond()
-                        val now = ZonedDateTime.now().toEpochSecond()
-                        val duration = now.seconds - startedAt.seconds
-                        val uptime = duration.toComponents { days, hours, minutes, _, _ ->
-                            buildString {
-                                append(" for ")
-                                if (days > 0) append("${days}d ")
-                                if (hours > 0) append("${hours}h ")
-                                append("${minutes}m")
-                            }
+                    // Calculate uptime
+                    val startedAt = Instant.parse(it.startedAt).atZone(ZoneId.systemDefault()).toEpochSecond()
+                    val now = ZonedDateTime.now().toEpochSecond()
+                    val duration = now.seconds - startedAt.seconds
+                    val uptime = duration.toComponents { days, hours, minutes, _, _ ->
+                        buildString {
+                            if (days > 0) append("${days}d ")
+                            if (hours > 0) append("${hours}h ")
+                            append("${minutes}m")
                         }
-                        formatted += uptime
-                    } catch(e: Exception) {}
+                    }
+
+                    val formatted = dankChatPreferenceStore.formatViewersString(it.viewerCount, uptime)
 
                     StreamData(channel = it.userLogin, formattedData = formatted)
                 }.orEmpty()

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
@@ -273,7 +273,7 @@ class DankChatPreferenceStore @Inject constructor(
         }
     }
 
-    fun formatViewersString(viewers: Int, uptime: String): String = context.resources.getQuantityString(R.plurals.viewers, viewers, viewers, uptime)
+    fun formatViewersString(viewers: Int, uptime: String): String = context.resources.getQuantityString(R.plurals.viewers_and_uptime, viewers, viewers, uptime)
 
     fun clearLogin() = dankChatPreferences.edit {
         putBoolean(LOGGED_IN_KEY, false)

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/DankChatPreferenceStore.kt
@@ -273,7 +273,7 @@ class DankChatPreferenceStore @Inject constructor(
         }
     }
 
-    fun formatViewersString(viewers: Int): String = context.resources.getQuantityString(R.plurals.viewers, viewers, viewers)
+    fun formatViewersString(viewers: Int, uptime: String): String = context.resources.getQuantityString(R.plurals.viewers, viewers, viewers, uptime)
 
     fun clearLogin() = dankChatPreferences.edit {
         putBoolean(LOGGED_IN_KEY, false)

--- a/app/src/main/kotlin/com/flxrs/dankchat/utils/DateTimeUtils.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/utils/DateTimeUtils.kt
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import kotlin.time.Duration.Companion.seconds
 
 object DateTimeUtils {
     private var timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
@@ -74,5 +75,21 @@ object DateTimeUtils {
         'd'  -> 60 * 60 * 24
         'w'  -> 60 * 60 * 24 * 7
         else -> null
+    }
+
+    fun calculateUptime(startedAt: String): String {
+        val startedAt = Instant.parse(startedAt).atZone(ZoneId.systemDefault()).toEpochSecond()
+        val now = ZonedDateTime.now().toEpochSecond()
+
+        val duration = now.seconds - startedAt.seconds
+        val uptime = duration.toComponents { days, hours, minutes, _, _ ->
+            buildString {
+                if (days > 0) append("${days}d ")
+                if (hours > 0) append("${hours}h ")
+                append("${minutes}m")
+            }
+        }
+
+        return uptime
     }
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/utils/DateTimeUtils.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/utils/DateTimeUtils.kt
@@ -77,8 +77,8 @@ object DateTimeUtils {
         else -> null
     }
 
-    fun calculateUptime(startedAt: String): String {
-        val startedAt = Instant.parse(startedAt).atZone(ZoneId.systemDefault()).toEpochSecond()
+    fun calculateUptime(startedAtString: String): String {
+        val startedAt = Instant.parse(startedAtString).atZone(ZoneId.systemDefault()).toEpochSecond()
         val now = ZonedDateTime.now().toEpochSecond()
 
         val duration = now.seconds - startedAt.seconds

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,8 +410,8 @@
     <string name="confirm_login_cancel_message">Are you sure you want to cancel the login process?</string>
     <string name="confirm_login_cancel_positive_button">Cancel login</string>
     <plurals name="viewers">
-        <item quantity="one">Live with %d viewer</item>
-        <item quantity="other">Live with %d viewers</item>
+        <item quantity="one">Live with %d viewer for %s</item>
+        <item quantity="other">Live with %d viewers for %s</item>
     </plurals>
     <plurals name="months">
         <item quantity="one">%d month</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,6 +410,10 @@
     <string name="confirm_login_cancel_message">Are you sure you want to cancel the login process?</string>
     <string name="confirm_login_cancel_positive_button">Cancel login</string>
     <plurals name="viewers">
+        <item quantity="one">Live with %d viewer</item>
+        <item quantity="other">Live with %d viewers</item>
+    </plurals>
+    <plurals name="viewers_and_uptime">
         <item quantity="one">Live with %d viewer for %s</item>
         <item quantity="other">Live with %d viewers for %s</item>
     </plurals>


### PR DESCRIPTION
This shows the stream uptime in the stream information below the chat input (issue #491). I updated the string resource to include the uptime and moved code that calculates the uptime to DateTimeUtils.kt.
Closes #491 