### PR TITLE
Implement highlighting based on user badges

### DIFF
--- a/app/schemas/com.flxrs.dankchat.data.database.DankChatDatabase/7.json
+++ b/app/schemas/com.flxrs.dankchat.data.database.DankChatDatabase/7.json
@@ -1,0 +1,410 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "6a6710155f6e95378180ba5e768da071",
+    "entities": [
+      {
+        "tableName": "badge_highlight",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `badgeName` TEXT NOT NULL, `isCustom` INTEGER NOT NULL, `create_notification` INTEGER NOT NULL, `custom_color` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "badgeName",
+            "columnName": "badgeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createNotification",
+            "columnName": "create_notification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customColor",
+            "columnName": "custom_color",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "emote_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`emote_id` TEXT NOT NULL, `last_used` INTEGER NOT NULL, PRIMARY KEY(`emote_id`))",
+        "fields": [
+          {
+            "fieldPath": "emoteId",
+            "columnName": "emote_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsed",
+            "columnName": "last_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "emote_id"
+          ]
+        }
+      },
+      {
+        "tableName": "upload",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `image_link` TEXT NOT NULL, `delete_link` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageLink",
+            "columnName": "image_link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleteLink",
+            "columnName": "delete_link",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "message_highlight",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `type` TEXT NOT NULL, `pattern` TEXT NOT NULL, `is_regex` INTEGER NOT NULL, `is_case_sensitive` INTEGER NOT NULL, `create_notification` INTEGER NOT NULL, `custom_color` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRegex",
+            "columnName": "is_regex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCaseSensitive",
+            "columnName": "is_case_sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createNotification",
+            "columnName": "create_notification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customColor",
+            "columnName": "custom_color",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "message_ignore",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `type` TEXT NOT NULL, `pattern` TEXT NOT NULL, `is_regex` INTEGER NOT NULL, `is_case_sensitive` INTEGER NOT NULL, `is_block_message` INTEGER NOT NULL, `replacement` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRegex",
+            "columnName": "is_regex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCaseSensitive",
+            "columnName": "is_case_sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlockMessage",
+            "columnName": "is_block_message",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replacement",
+            "columnName": "replacement",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_highlight",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `username` TEXT NOT NULL, `create_notification` INTEGER NOT NULL, `custom_color` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createNotification",
+            "columnName": "create_notification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customColor",
+            "columnName": "custom_color",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "blacklisted_user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `username` TEXT NOT NULL, `is_regex` INTEGER NOT NULL, `is_case_sensitive` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRegex",
+            "columnName": "is_regex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCaseSensitive",
+            "columnName": "is_case_sensitive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "blacklisted_user_highlight",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `username` TEXT NOT NULL, `is_regex` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRegex",
+            "columnName": "is_regex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_display",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `target_user` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `color_enabled` INTEGER NOT NULL, `color` INTEGER NOT NULL, `aliasEnabled` INTEGER NOT NULL, `alias` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetUser",
+            "columnName": "target_user",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorEnabled",
+            "columnName": "color_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aliasEnabled",
+            "columnName": "aliasEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6a6710155f6e95378180ba5e768da071')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/flxrs/dankchat/chat/ChatAdapter.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/chat/ChatAdapter.kt
@@ -900,6 +900,7 @@ class ChatAdapter(
             HighlightType.ElevatedMessage                          -> ContextCompat.getColor(context, R.color.color_elevated_message_highlight)
             HighlightType.FirstMessage                             -> ContextCompat.getColor(context, R.color.color_first_message_highlight)
             HighlightType.Username                                 -> ContextCompat.getColor(context, R.color.color_mention_highlight)
+            HighlightType.Badge                                    -> ContextCompat.getColor(context, R.color.color_mention_highlight)
             HighlightType.Custom                                   -> ContextCompat.getColor(context, R.color.color_mention_highlight)
             HighlightType.Reply                                    -> ContextCompat.getColor(context, R.color.color_mention_highlight)
             HighlightType.Notification                             -> ContextCompat.getColor(context, R.color.color_mention_highlight)

--- a/app/src/main/kotlin/com/flxrs/dankchat/chat/ChatAdapter.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/chat/ChatAdapter.kt
@@ -900,7 +900,7 @@ class ChatAdapter(
             HighlightType.ElevatedMessage                          -> ContextCompat.getColor(context, R.color.color_elevated_message_highlight)
             HighlightType.FirstMessage                             -> ContextCompat.getColor(context, R.color.color_first_message_highlight)
             HighlightType.Username                                 -> ContextCompat.getColor(context, R.color.color_mention_highlight)
-            HighlightType.Badge                                    -> ContextCompat.getColor(context, R.color.color_mention_highlight)
+            HighlightType.Badge                                    -> highlight.customColor ?: ContextCompat.getColor(context, R.color.color_mention_highlight)
             HighlightType.Custom                                   -> ContextCompat.getColor(context, R.color.color_mention_highlight)
             HighlightType.Reply                                    -> ContextCompat.getColor(context, R.color.color_mention_highlight)
             HighlightType.Notification                             -> ContextCompat.getColor(context, R.color.color_mention_highlight)

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/database/DankChatDatabase.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/database/DankChatDatabase.kt
@@ -11,8 +11,9 @@ import com.flxrs.dankchat.data.database.dao.*
 import com.flxrs.dankchat.data.database.entity.*
 
 @Database(
-    version = 6,
+    version = 7,
     entities = [
+        BadgeHighlightEntity::class,
         EmoteUsageEntity::class,
         UploadEntity::class,
         MessageHighlightEntity::class,
@@ -27,11 +28,13 @@ import com.flxrs.dankchat.data.database.entity.*
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 6, to = 7),
     ],
     exportSchema = true,
 )
 @TypeConverters(InstantConverter::class)
 abstract class DankChatDatabase : RoomDatabase() {
+    abstract fun badgeHighlightDao(): BadgeHighlightDao
     abstract fun emoteUsageDao(): EmoteUsageDao
     abstract fun recentUploadsDao(): RecentUploadsDao
     abstract fun userDisplayDao(): UserDisplayDao

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/database/dao/BadgeHighlightDao.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/database/dao/BadgeHighlightDao.kt
@@ -1,0 +1,33 @@
+package com.flxrs.dankchat.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import com.flxrs.dankchat.data.database.entity.BadgeHighlightEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BadgeHighlightDao {
+
+    @Query("SELECT * FROM badge_highlight WHERE id = :id")
+    suspend fun getBadgeHighlight(id: Long): BadgeHighlightEntity
+
+    @Query("SELECT * FROM badge_highlight")
+    suspend fun getBadgeHighlights(): List<BadgeHighlightEntity>
+
+    @Query("SELECT * FROM badge_highlight")
+    fun getBadgeHighlightsFlow(): Flow<List<BadgeHighlightEntity>>
+
+    @Upsert
+    suspend fun addHighlight(highlight: BadgeHighlightEntity): Long
+
+    @Upsert
+    suspend fun addHighlights(highlights: List<BadgeHighlightEntity>)
+
+    @Delete
+    suspend fun deleteHighlight(highlight: BadgeHighlightEntity)
+
+    @Query("DELETE FROM badge_highlight")
+    suspend fun deleteAllHighlights()
+}

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/database/entity/BadgeHighlightEntity.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/database/entity/BadgeHighlightEntity.kt
@@ -1,0 +1,20 @@
+package com.flxrs.dankchat.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "badge_highlight")
+data class BadgeHighlightEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long,
+    val enabled: Boolean,
+    val badgeName: String,
+    val isCustom: Boolean,
+
+    @ColumnInfo(name = "create_notification")
+    val createNotification: Boolean = false,
+
+    @ColumnInfo(name = "custom_color")
+    val customColor: Int? = null
+)

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
@@ -429,13 +429,13 @@ class HighlightsRepository(
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.Reply, pattern = ""),
         )
         private val DEFAULT_BADGE_HIGHLIGHTS = listOf(
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "broadcaster", isCustom = false),
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "admin", isCustom = false),
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "staff", isCustom = false),
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "moderator", isCustom = false),
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "lead_moderator", isCustom = false),
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "partner", isCustom = false),
-            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "vip", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "broadcaster", isCustom = false, customColor = 0x7f7f3f49.toInt()),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "admin", isCustom = false, customColor = 0x7f8f3018.toInt()),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "staff", isCustom = false, customColor = 0x7f8f3018.toInt()),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "moderator", isCustom = false, customColor = 0x731f8d2b.toInt()),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "lead_moderator", isCustom = false, customColor = 0x731f8d2b.toInt()),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "partner", isCustom = false, customColor = 0x64c466ff.toInt()),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "vip", isCustom = false, customColor = 0x7fc12ea9.toInt()),
             BadgeHighlightEntity(id = 0, enabled = false, badgeName = "founder", isCustom = false),
             BadgeHighlightEntity(id = 0, enabled = false, badgeName = "subscriber", isCustom = false),
         )

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
@@ -5,9 +5,11 @@ package com.flxrs.dankchat.data.repo
 import android.util.Log
 import com.flxrs.dankchat.data.DisplayName
 import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.data.database.dao.BadgeHighlightDao
 import com.flxrs.dankchat.data.database.dao.BlacklistedUserDao
 import com.flxrs.dankchat.data.database.dao.MessageHighlightDao
 import com.flxrs.dankchat.data.database.dao.UserHighlightDao
+import com.flxrs.dankchat.data.database.entity.BadgeHighlightEntity
 import com.flxrs.dankchat.data.database.entity.BlacklistedUserEntity
 import com.flxrs.dankchat.data.database.entity.MessageHighlightEntity
 import com.flxrs.dankchat.data.database.entity.MessageHighlightEntityType
@@ -40,6 +42,7 @@ import org.koin.core.annotation.Single
 class HighlightsRepository(
     private val messageHighlightDao: MessageHighlightDao,
     private val userHighlightDao: UserHighlightDao,
+    private val badgeHighlightDao: BadgeHighlightDao,
     private val blacklistedUserDao: BlacklistedUserDao,
     private val preferences: DankChatPreferenceStore,
     private val notificationsSettingsDataStore: NotificationsSettingsDataStore,
@@ -57,6 +60,7 @@ class HighlightsRepository(
         .stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
 
     val userHighlights = userHighlightDao.getUserHighlightsFlow().stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
+    val badgeHighlights = badgeHighlightDao.getBadgeHighlightsFlow().stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
     val blacklistedUsers = blacklistedUserDao.getBlacklistedUserFlow().stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
 
     private val validMessageHighlights = messageHighlights
@@ -64,6 +68,9 @@ class HighlightsRepository(
         .stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
     private val validUserHighlights = userHighlights
         .map { highlights -> highlights.filter { it.enabled && it.username.isNotBlank() } }
+        .stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
+    private val validBadgeHighlights = badgeHighlights
+        .map { highlights -> highlights.filter { it.enabled && it.badgeName.isNotBlank() } }
         .stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
     private val validBlacklistedUsers = blacklistedUsers
         .map { highlights -> highlights.filter { it.enabled && it.username.isNotBlank() } }
@@ -95,6 +102,7 @@ class HighlightsRepository(
             runCatching {
                 messageHighlightDao.deleteAllHighlights()
                 userHighlightDao.deleteAllHighlights()
+                badgeHighlightDao.deleteAllHighlights()
                 return@launch
             }
         }
@@ -143,6 +151,29 @@ class HighlightsRepository(
 
     suspend fun updateUserHighlights(entities: List<UserHighlightEntity>) {
         userHighlightDao.addHighlights(entities)
+    }
+
+    suspend fun addBadgeHighlight(): BadgeHighlightEntity {
+        val entity = BadgeHighlightEntity(
+            id = 0,
+            enabled = true,
+            badgeName = "",
+            isCustom = true,
+        )
+        val id = badgeHighlightDao.addHighlight(entity)
+        return entity.copy(id = id)
+    }
+
+    suspend fun updateBadgeHighlight(entity: BadgeHighlightEntity) {
+        badgeHighlightDao.addHighlight(entity)
+    }
+
+    suspend fun removeBadgeHighlight(entity: BadgeHighlightEntity) {
+        badgeHighlightDao.deleteHighlight(entity)
+    }
+
+    suspend fun updateBadgeHighlights(entities: List<BadgeHighlightEntity>) {
+        badgeHighlightDao.addHighlights(entities)
     }
 
     suspend fun addBlacklistedUser(): BlacklistedUserEntity {
@@ -209,6 +240,7 @@ class HighlightsRepository(
         }
 
         val userHighlights = validUserHighlights.value
+        val badgeHighlights = validBadgeHighlights.value
         val messageHighlights = validMessageHighlights.value
         val highlights = buildSet {
             if (isSub && messageHighlights.areSubsEnabled) {
@@ -306,6 +338,12 @@ class HighlightsRepository(
     }
 
     private fun MutableCollection<Highlight>.addNotificationHighlightIfEnabled(highlightEntity: UserHighlightEntity) {
+        if (highlightEntity.createNotification) {
+            add(Highlight(HighlightType.Notification))
+        }
+    }
+
+    private fun MutableCollection<Highlight>.addNotificationHighlightIfEnabled(highlightEntity: BadgeHighlightEntity) {
         if (highlightEntity.createNotification) {
             add(Highlight(HighlightType.Notification))
         }

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
@@ -296,6 +296,22 @@ class HighlightsRepository(
                     addNotificationHighlightIfEnabled(it)
                 }
             }
+            badgeHighlights.forEach { highlight ->
+                badges.forEach { badge ->
+                    val tag = badge.badgeTag ?: return@forEach
+                    if (tag.isNotBlank()) {
+                        val match = if (highlight.badgeName.contains("/")) {
+                            tag == highlight.badgeName
+                        } else {
+                            tag.startsWith(highlight.badgeName + "/")
+                        }
+                        if (match) {
+                            add(Highlight(HighlightType.Badge, highlight.customColor))
+                            addNotificationHighlightIfEnabled(highlight)
+                        }
+                    }
+                }
+            }
         }
 
         return copy(highlights = highlights)

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
@@ -60,7 +60,8 @@ class HighlightsRepository(
         .stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
 
     val userHighlights = userHighlightDao.getUserHighlightsFlow().stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
-    val badgeHighlights = badgeHighlightDao.getBadgeHighlightsFlow().stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
+    val badgeHighlights = badgeHighlightDao.getBadgeHighlightsFlow()
+        .stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
     val blacklistedUsers = blacklistedUserDao.getBlacklistedUserFlow().stateIn(coroutineScope, SharingStarted.Eagerly, emptyList())
 
     private val validMessageHighlights = messageHighlights
@@ -88,15 +89,18 @@ class HighlightsRepository(
 
     fun runMigrationsIfNeeded() = coroutineScope.launch {
         runCatching {
-            if (messageHighlightDao.getMessageHighlights().isNotEmpty()) {
-                return@launch
+            if (messageHighlightDao.getMessageHighlights().isEmpty()) {
+                Log.d(TAG, "Running message highlights migration...")
+                messageHighlightDao.addHighlights(DEFAULT_MESSAGE_HIGHLIGHTS)
+                val totalMessageHighlights = DEFAULT_MESSAGE_HIGHLIGHTS.size
+                Log.d(TAG, "Message highlights migration completed, added $totalMessageHighlights entries.")
             }
-
-            Log.d(TAG, "Running highlights migration...")
-            messageHighlightDao.addHighlights(DEFAULT_HIGHLIGHTS)
-
-            val totalHighlights = DEFAULT_HIGHLIGHTS.size
-            Log.d(TAG, "Highlights migration completed, added $totalHighlights entries.")
+            if (badgeHighlightDao.getBadgeHighlights().isEmpty()) {
+                Log.d(TAG, "Running badge highlights migration...")
+                badgeHighlightDao.addHighlights(DEFAULT_BADGE_HIGHLIGHTS)
+                val totalBadgeHighlights =  + DEFAULT_BADGE_HIGHLIGHTS.size
+                Log.d(TAG, "Badge highlights migration completed, added $totalBadgeHighlights entries.")
+            }
         }.getOrElse {
             Log.e(TAG, "Failed to run highlights migration", it)
             runCatching {
@@ -405,7 +409,7 @@ class HighlightsRepository(
     }
 
     private fun List<MessageHighlightEntity>.addDefaultsIfNecessary(): List<MessageHighlightEntity> {
-        return (this + DEFAULT_HIGHLIGHTS).distinctBy {
+        return (this + DEFAULT_MESSAGE_HIGHLIGHTS).distinctBy {
             when (it.type) {
                 MessageHighlightEntityType.Custom -> it.id
                 else                              -> it.type
@@ -415,7 +419,7 @@ class HighlightsRepository(
 
     companion object {
         private val TAG = HighlightsRepository::class.java.simpleName
-        private val DEFAULT_HIGHLIGHTS = listOf(
+        private val DEFAULT_MESSAGE_HIGHLIGHTS = listOf(
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.Username, pattern = ""),
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.Subscription, pattern = "", createNotification = false),
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.Announcement, pattern = "", createNotification = false),
@@ -423,6 +427,17 @@ class HighlightsRepository(
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.FirstMessage, pattern = "", createNotification = false),
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.ElevatedMessage, pattern = "", createNotification = false),
             MessageHighlightEntity(id = 0, enabled = true, type = MessageHighlightEntityType.Reply, pattern = ""),
+        )
+        private val DEFAULT_BADGE_HIGHLIGHTS = listOf(
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "broadcaster", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "admin", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "staff", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "moderator", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "lead_moderator", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "partner", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "vip", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "founder", isCustom = false),
+            BadgeHighlightEntity(id = 0, enabled = false, badgeName = "subscriber", isCustom = false),
         )
     }
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/chat/ChatRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/chat/ChatRepository.kt
@@ -664,9 +664,9 @@ class ChatRepository(
             Message.parse(ircMessage, channelRepository::tryGetUserNameById)
                 ?.applyIgnores()
                 ?.calculateMessageThread { channel, id -> messages[channel]?.value?.find { it.message.id == id }?.message }
-                ?.calculateHighlightState()
                 ?.calculateUserDisplays()
                 ?.parseEmotesAndBadges()
+                ?.calculateHighlightState()
                 ?.updateMessageInThread()
         }.getOrElse {
             Log.e(TAG, "Failed to parse message", it)
@@ -827,9 +827,9 @@ class ChatRepository(
                             Message.parse(parsedIrc, channelRepository::tryGetUserNameById)
                                 ?.applyIgnores()
                                 ?.calculateMessageThread { _, id -> items.find { it.message.id == id }?.message }
-                                ?.calculateHighlightState()
                                 ?.calculateUserDisplays()
                                 ?.parseEmotesAndBadges()
+                                ?.calculateHighlightState()
                                 ?.updateMessageInThread()
                         }.getOrNull() ?: continue
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/HighlightState.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/HighlightState.kt
@@ -23,6 +23,7 @@ enum class HighlightType(val priority: HighlightPriority) {
     FirstMessage(HighlightPriority.MEDIUM),
     ElevatedMessage(HighlightPriority.MEDIUM),
     Username(HighlightPriority.LOW),
+    Badge(HighlightPriority.LOW),
     Custom(HighlightPriority.LOW),
     Reply(HighlightPriority.LOW),
     Notification(HighlightPriority.LOW),

--- a/app/src/main/kotlin/com/flxrs/dankchat/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.flxrs.dankchat.di
 import android.content.Context
 import androidx.room.Room
 import com.flxrs.dankchat.data.database.DankChatDatabase
+import com.flxrs.dankchat.data.database.dao.BadgeHighlightDao
 import com.flxrs.dankchat.data.database.dao.BlacklistedUserDao
 import com.flxrs.dankchat.data.database.dao.EmoteUsageDao
 import com.flxrs.dankchat.data.database.dao.MessageHighlightDao
@@ -49,6 +50,11 @@ class DatabaseModule {
     fun provideUserHighlightDao(
         database: DankChatDatabase
     ): UserHighlightDao = database.userHighlightDao()
+
+    @Single
+    fun provideBadgeHighlightDao(
+        database: DankChatDatabase
+    ): BadgeHighlightDao = database.badgeHighlightDao()
 
     @Single
     fun provideIgnoreUserDao(

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightItem.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightItem.kt
@@ -1,5 +1,6 @@
 package com.flxrs.dankchat.preferences.notifications.highlights
 
+import com.flxrs.dankchat.data.database.entity.BadgeHighlightEntity
 import com.flxrs.dankchat.data.database.entity.BlacklistedUserEntity
 import com.flxrs.dankchat.data.database.entity.MessageHighlightEntity
 import com.flxrs.dankchat.data.database.entity.MessageHighlightEntityType
@@ -43,6 +44,16 @@ data class UserHighlightItem(
     override val id: Long,
     val enabled: Boolean,
     val username: String,
+    val createNotification: Boolean,
+    val notificationsEnabled: Boolean,
+) : HighlightItem
+
+data class BadgeHighlightItem(
+    override val id: Long,
+    val enabled: Boolean,
+    val badgeName: String,
+    val isCustom: Boolean,
+    val customColor: Int?,
     val createNotification: Boolean,
     val notificationsEnabled: Boolean,
 ) : HighlightItem
@@ -110,6 +121,25 @@ fun UserHighlightItem.toEntity() = UserHighlightEntity(
     id = id,
     enabled = enabled,
     username = username,
+    createNotification = createNotification,
+)
+
+fun BadgeHighlightEntity.toItem(notificationsEnabled: Boolean) = BadgeHighlightItem(
+    id = id,
+    enabled = enabled,
+    badgeName = badgeName,
+    isCustom = isCustom,
+    customColor = customColor,
+    createNotification = createNotification,
+    notificationsEnabled = notificationsEnabled,
+)
+
+fun BadgeHighlightItem.toEntity() = BadgeHighlightEntity(
+    id = id,
+    enabled = enabled,
+    badgeName = badgeName,
+    isCustom = isCustom,
+    customColor = customColor,
     createNotification = createNotification,
 )
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsScreen.kt
@@ -88,6 +88,7 @@ fun HighlightsScreen(onNavBack: () -> Unit) {
         currentTab = currentTab,
         messageHighlights = viewModel.messageHighlights,
         userHighlights = viewModel.userHighlights,
+        badgeHighlights = viewModel.badgeHighlights,
         blacklistedUsers = viewModel.blacklistedUsers,
         eventsWrapper = events,
         onSave = viewModel::updateHighlights,
@@ -104,9 +105,10 @@ private fun HighlightsScreen(
     currentTab: HighlightsTab,
     messageHighlights: SnapshotStateList<MessageHighlightItem>,
     userHighlights: SnapshotStateList<UserHighlightItem>,
+    badgeHighlights: SnapshotStateList<BadgeHighlightItem>,
     blacklistedUsers: SnapshotStateList<BlacklistedUserItem>,
     eventsWrapper: HighlightEventsWrapper,
-    onSave: (List<MessageHighlightItem>, List<UserHighlightItem>, List<BlacklistedUserItem>) -> Unit,
+    onSave: (List<MessageHighlightItem>, List<UserHighlightItem>, List<BlacklistedUserItem>, List<BadgeHighlightItem>) -> Unit,
     onRemove: (HighlightItem) -> Unit,
     onAddNew: () -> Unit,
     onAdd: (HighlightItem, Int) -> Unit,
@@ -159,7 +161,7 @@ private fun HighlightsScreen(
 
     LifecycleStartEffect(Unit) {
         onStopOrDispose {
-            onSave(messageHighlights, userHighlights, blacklistedUsers)
+            onSave(messageHighlights, userHighlights, blacklistedUsers, badgeHighlights)
         }
     }
 
@@ -176,7 +178,7 @@ private fun HighlightsScreen(
                 navigationIcon = {
                     IconButton(
                         onClick = {
-                            onSave(messageHighlights, userHighlights, blacklistedUsers)
+                            onSave(messageHighlights, userHighlights, blacklistedUsers, badgeHighlights)
                             onNavBack()
                         },
                         content = { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back)) },
@@ -207,6 +209,7 @@ private fun HighlightsScreen(
                 val subtitle = when (currentTab) {
                     HighlightsTab.Messages         -> stringResource(R.string.highlights_messages_title)
                     HighlightsTab.Users            -> stringResource(R.string.highlights_users_title)
+                    HighlightsTab.Badges           -> stringResource(R.string.highlights_badges_title)
                     HighlightsTab.BlacklistedUsers -> stringResource(R.string.highlights_blacklisted_users_title)
                 }
                 Text(
@@ -225,6 +228,7 @@ private fun HighlightsScreen(
                         when (HighlightsTab.entries[it]) {
                             HighlightsTab.Messages         -> stringResource(R.string.tab_messages)
                             HighlightsTab.Users            -> stringResource(R.string.tab_users)
+                            HighlightsTab.Badges           -> stringResource(R.string.tab_badges)
                             HighlightsTab.BlacklistedUsers -> stringResource(R.string.tab_blacklisted_users)
                         }
                     }
@@ -262,6 +266,21 @@ private fun HighlightsScreen(
                             item = item,
                             onChanged = { userHighlights[idx] = it },
                             onRemove = { onRemove(userHighlights[idx]) },
+                            modifier = Modifier.animateItem(
+                                fadeInSpec = null,
+                                fadeOutSpec = null,
+                            ),
+                        )
+                    }
+
+                    HighlightsTab.Badges           -> HighlightsList(
+                        highlights = badgeHighlights,
+                        listState = listState,
+                    ) { idx, item ->
+                        BadgeHighlightItem(
+                            item = item,
+                            onChanged = { badgeHighlights[idx] = it },
+                            onRemove = { onRemove(badgeHighlights[idx]) },
                             modifier = Modifier.animateItem(
                                 fadeInSpec = null,
                                 fadeOutSpec = null,
@@ -435,6 +454,80 @@ private fun UserHighlightItem(
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     maxLines = 1,
                 )
+                FlowRow(
+                    modifier = Modifier.padding(top = 8.dp),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    CheckboxWithText(
+                        text = stringResource(R.string.enabled),
+                        checked = item.enabled,
+                        onCheckedChange = { onChanged(item.copy(enabled = it)) },
+                        modifier = modifier.padding(end = 8.dp),
+                    )
+                    CheckboxWithText(
+                        text = stringResource(R.string.create_notification),
+                        checked = item.createNotification,
+                        onCheckedChange = { onChanged(item.copy(createNotification = it)) },
+                        enabled = item.enabled && item.notificationsEnabled,
+                    )
+                }
+            }
+            IconButton(
+                onClick = onRemove,
+                content = { Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BadgeHighlightItem(
+    item: BadgeHighlightItem,
+    onChanged: (BadgeHighlightItem) -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(modifier) {
+        Row {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(8.dp),
+            ) {
+                if (item.isCustom) {
+                    OutlinedTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = item.badgeName,
+                        onValueChange = { onChanged(item.copy(badgeName = it)) },
+                        label = { Text(stringResource(R.string.badge)) },
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        maxLines = 1,
+                    )
+                } else {
+                    var name = ""
+                    when (item.badgeName) {
+                        "broadcaster"-> name = stringResource(R.string.badge_broadcaster)
+                        "admin"-> name = stringResource(R.string.badge_admin)
+                        "staff"-> name = stringResource(R.string.badge_staff)
+                        "moderator"-> name = stringResource(R.string.badge_moderator)
+                        "lead_moderator"-> name = stringResource(R.string.badge_lead_moderator)
+                        "partner"-> name = stringResource(R.string.badge_verified)
+                        "vip"-> name = stringResource(R.string.badge_vip)
+                        "founder"-> name = stringResource(R.string.badge_founder)
+                        "subscriber"-> name = stringResource(R.string.badge_subscriber)
+                    }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp)
+                    ) {
+                        Text(
+                            text = name,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
+                }
                 FlowRow(
                     modifier = Modifier.padding(top = 8.dp),
                     verticalArrangement = Arrangement.Center,

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsScreen.kt
@@ -546,10 +546,12 @@ private fun BadgeHighlightItem(
                     )
                 }
             }
-            IconButton(
-                onClick = onRemove,
-                content = { Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear)) },
-            )
+            if (item.isCustom) {
+                IconButton(
+                    onClick = onRemove,
+                    content = { Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear)) },
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsTab.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsTab.kt
@@ -4,4 +4,5 @@ enum class HighlightsTab {
     Messages,
     Users,
     BlacklistedUsers,
+    Badges,
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/highlights/HighlightsViewModel.kt
@@ -30,6 +30,7 @@ class HighlightsViewModel(
 
     val messageHighlights = SnapshotStateList<MessageHighlightItem>()
     val userHighlights = SnapshotStateList<UserHighlightItem>()
+    val badgeHighlights = SnapshotStateList<BadgeHighlightItem>()
     val blacklistedUsers = SnapshotStateList<BlacklistedUserItem>()
 
     val events = eventChannel.receiveAsFlow()
@@ -44,10 +45,12 @@ class HighlightsViewModel(
         val notificationsEnabled = notificationsSettingsDataStore.settings.first().showNotifications
         val messageHighlightItems = highlightsRepository.messageHighlights.value.map { it.toItem(loggedIn, notificationsEnabled) }
         val userHighlightItems = highlightsRepository.userHighlights.value.map { it.toItem(notificationsEnabled) }
+        val badgeHighlightItems = highlightsRepository.badgeHighlights.value.map { it.toItem(notificationsEnabled) }
         val blacklistedUserItems = highlightsRepository.blacklistedUsers.value.map { it.toItem() }
 
         messageHighlights.replaceAll(messageHighlightItems)
         userHighlights.replaceAll(userHighlightItems)
+        badgeHighlights.replaceAll(badgeHighlightItems)
         blacklistedUsers.replaceAll(blacklistedUserItems)
     }
 
@@ -66,6 +69,12 @@ class HighlightsViewModel(
                 val entity = highlightsRepository.addUserHighlight()
                 userHighlights +=  entity.toItem(notificationsEnabled)
                 position = userHighlights.lastIndex
+            }
+
+            HighlightsTab.Badges           -> {
+                val entity = highlightsRepository.addBadgeHighlight()
+                badgeHighlights +=  entity.toItem(notificationsEnabled)
+                position = badgeHighlights.lastIndex
             }
 
             HighlightsTab.BlacklistedUsers -> {
@@ -92,6 +101,12 @@ class HighlightsViewModel(
                 isLast = position == userHighlights.lastIndex
             }
 
+            is BadgeHighlightItem    -> {
+                highlightsRepository.updateBadgeHighlight(item.toEntity())
+                badgeHighlights.add(position, item)
+                isLast = position == badgeHighlights.lastIndex
+            }
+
             is BlacklistedUserItem  -> {
                 highlightsRepository.updateBlacklistedUser(item.toEntity())
                 blacklistedUsers.add(position, item)
@@ -116,6 +131,12 @@ class HighlightsViewModel(
                 userHighlights.removeAt(position)
             }
 
+            is BadgeHighlightItem    -> {
+                position = badgeHighlights.indexOfFirst { it.id == item.id }
+                highlightsRepository.removeBadgeHighlight(item.toEntity())
+                badgeHighlights.removeAt(position)
+            }
+
             is BlacklistedUserItem  -> {
                 position = blacklistedUsers.indexOfFirst { it.id == item.id }
                 highlightsRepository.removeBlacklistedUser(item.toEntity())
@@ -129,6 +150,7 @@ class HighlightsViewModel(
         messageHighlightItems: List<MessageHighlightItem>,
         userHighlightItems: List<UserHighlightItem>,
         blacklistedUserHighlightItems: List<BlacklistedUserItem>,
+        badgeHighlightItems: List<BadgeHighlightItem>,
     ) = viewModelScope.launch {
         filterMessageHighlights(messageHighlightItems).let { (blankEntities, entities) ->
             highlightsRepository.updateMessageHighlights(entities)
@@ -138,6 +160,11 @@ class HighlightsViewModel(
         filterUserHighlights(userHighlightItems).let { (blankEntities, entities) ->
             highlightsRepository.updateUserHighlights(entities)
             blankEntities.forEach { highlightsRepository.removeUserHighlight(it) }
+        }
+
+        filterBadgeHighlights(badgeHighlightItems).let { (blankEntities, entities) ->
+            highlightsRepository.updateBadgeHighlights(entities)
+            blankEntities.forEach { highlightsRepository.removeBadgeHighlight(it) }
         }
 
         filterBlacklistedUsers(blacklistedUserHighlightItems).let { (blankEntities, entities) ->
@@ -153,6 +180,10 @@ class HighlightsViewModel(
     private fun filterUserHighlights(items: List<UserHighlightItem>) = items
         .map { it.toEntity() }
         .partition { it.username.isBlank() }
+
+    private fun filterBadgeHighlights(items: List<BadgeHighlightItem>) = items
+        .map { it.toEntity() }
+        .partition { it.badgeName.isBlank() }
 
     private fun filterBlacklistedUsers(items: List<BlacklistedUserItem>) = items
         .map { it.toEntity() }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,10 +373,12 @@
     <string name="tab_users">Users</string>
     <string name="tab_blacklisted_users">Blacklisted Users</string>
     <string name="tab_twitch">Twitch</string>
+    <string name="tab_badges">Badges</string>
     <string name="undo">Undo</string>
     <string name="item_removed">Item removed</string>
     <string name="unblocked_user">Unblocked user %1$s</string>
     <string name="unblocked_user_failed">Failed to unblock user %1$s</string>
+    <string name="badge">Badge</string>
     <string name="blocked_user_failed">Failed to block user %1$s</string>
     <string name="highlights_entry_username">Your username</string>
     <string name="highlights_ignores_entry_subscriptions">Subscriptions and Events</string>
@@ -389,6 +391,7 @@
     <string name="highlights_messages_title">Creates notifications and highlights messages based on certain patterns.</string>
     <string name="highlights_users_title">Creates notifications and highlights messages from certain users.</string>
     <string name="highlights_blacklisted_users_title">Disable notifications and highlights from certain users (e.g. bots).</string>
+    <string name="highlights_badges_title">Create notifications and highlights messages from users based on badges.</string>
     <string name="ignores_messages_title">Ignore messages based on certain patterns.</string>
     <string name="ignores_users_title">Ignore messages from certain users.</string>
     <string name="ignores_twitch_title">Manage blocked Twitch users.</string>
@@ -454,4 +457,13 @@
     <string name="preference_streaminfo_category_title">Show stream category</string>
     <string name="preference_streaminfo_category_summary">Also display stream category</string>
     <string name="toggle_input">Toggle input</string>
+    <string name="badge_broadcaster">Broadcaster</string>
+    <string name="badge_admin">Admin</string>
+    <string name="badge_staff">Staff</string>
+    <string name="badge_moderator">Moderator</string>
+    <string name="badge_lead_moderator">Lead Moderator</string>
+    <string name="badge_verified">Verified</string>
+    <string name="badge_vip">VIP</string>
+    <string name="badge_founder">Founder</string>
+    <string name="badge_subscriber">Subscriber</string>
 </resources>


### PR DESCRIPTION
This PR implements highlighting of messages based on the badges of a user, similar to one of Chatterino's options. The default set of badge highlights are Broadcaster, Admin, Staff, Moderator, Verified, VIP, Founder, and Subscriber. The colors chosen for the highlights are default colors from Chatterino that are similar colors to each badge's main color. The exceptions are Founder and Subscriber which do not have a custom color but rather use the default mention highlight color. The default set are not highlighted by default, but are made available in the settings so that users can enable them if they want.

Users can also provide their own badge matching strings to get any such messages highlighted with the default mention color. But these strings are not very intuitive which is why I included the default set.

Closes #453