### PR TITLE
Enable user ignore text field

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/ignores/IgnoresScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/notifications/ignores/IgnoresScreen.kt
@@ -474,7 +474,7 @@ private fun UserIgnoreItem(
             ) {
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = false,
+                    enabled = true,
                     value = item.username,
                     onValueChange = { onChanged(item.copy(username = it)) },
                     label = { Text(stringResource(R.string.username)) },


### PR DESCRIPTION
The text field for adding a user ignore was disabled making it not possible to add a user ignore. It should be enabled.