### PR TITLE
fix(stream): log main-frame WebView load errors via onReceivedError

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/stream/StreamView.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/stream/StreamView.kt
@@ -1,6 +1,5 @@
 package com.flxrs.dankchat.ui.main.stream
 
-import android.os.Build
 import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.RenderProcessGoneDetail
@@ -286,11 +285,7 @@ private class StreamComposeWebViewClient(
     ) {
         super.onReceivedError(view, request, error)
         if (request?.isForMainFrame != true) return
-        val description = if (Build.VERSION.SDK_INT >= 23) {
-            error?.description?.toString().orEmpty()
-        } else {
-            ""
-        }
+        val description = error?.description?.toString().orEmpty()
         logger.warn { "Stream WebView failed to load ${request.url}: $description" }
     }
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/stream/StreamView.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/stream/StreamView.kt
@@ -1,8 +1,10 @@
 package com.flxrs.dankchat.ui.main.stream
 
+import android.os.Build
 import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -44,6 +46,7 @@ import androidx.core.view.doOnAttach
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flxrs.dankchat.R
 import com.flxrs.dankchat.data.UserName
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -276,7 +279,23 @@ private class StreamComposeWebViewClient(
         return ALLOWED_PATHS.none { url.startsWith(it) }
     }
 
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError?,
+    ) {
+        super.onReceivedError(view, request, error)
+        if (request?.isForMainFrame != true) return
+        val description = if (Build.VERSION.SDK_INT >= 23) {
+            error?.description?.toString().orEmpty()
+        } else {
+            ""
+        }
+        logger.warn { "Stream WebView failed to load ${request.url}: $description" }
+    }
+
     companion object {
+        private val logger = KotlinLogging.logger("StreamComposeWebViewClient")
         private const val BLANK_URL = "about:blank"
         private val ALLOWED_PATHS =
             listOf(


### PR DESCRIPTION
Closes #1133.

The two stream-overlay `WebViewClient`s in `ui/main/stream/` (`StreamWebView.kt` and `StreamView.kt`) override `shouldOverrideUrlLoading` (plus `onPageFinished` on the Compose one) but neither overrides `onReceivedError`. When the embed fails to load (network drop, DNS, the player URL moves), the WebView just stays blank with nothing in the log to point at.

Add a main-frame-only `onReceivedError` override on both clients that logs the failing URL and description through the existing `KotlinLogging.logger(...)` used elsewhere in the codebase:

```kotlin
override fun onReceivedError(
    view: WebView?,
    request: WebResourceRequest?,
    error: WebResourceError?,
) {
    super.onReceivedError(view, request, error)
    if (request?.isForMainFrame != true) return
    val description = if (Build.VERSION.SDK_INT >= 23) {
        error?.description?.toString().orEmpty()
    } else {
        ""
    }
    logger.warn { "Stream WebView failed to load ${request.url}: $description" }
}
```

`isForMainFrame` gate keeps blocked sub-resources from spamming the log on every embed. No UX change: the overlay still does the same thing on success, but stream playback failures now leave a trace.
