### PR TITLE
feat: wrap ascii art at twitch web chat width

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/AsciiArt.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/AsciiArt.kt
@@ -1,0 +1,36 @@
+package com.flxrs.dankchat.data.twitch.message
+
+import java.text.BreakIterator
+import java.util.Locale
+
+private const val MIN_ART_CELLS = 40
+
+/**
+ * Checks whether this message contains enough Unicode symbols to be ASCII art.
+ */
+internal fun String.isAsciiArt(): Boolean = countArtCells() >= MIN_ART_CELLS
+
+private fun String.countArtCells(): Int {
+    val boundaries = BreakIterator.getCharacterInstance(Locale.ROOT)
+    boundaries.setText(this)
+
+    var cells = 0
+    var start = boundaries.first()
+    var end = boundaries.next()
+    while (end != BreakIterator.DONE) {
+        if (substring(start, end).codePoints().anyMatch(::isArtCodePoint)) {
+            cells++
+        }
+        start = end
+        end = boundaries.next()
+    }
+    return cells
+}
+
+private fun isArtCodePoint(codePoint: Int): Boolean = when (Character.getType(codePoint)) {
+    Character.OTHER_SYMBOL.toInt(),
+    Character.MODIFIER_SYMBOL.toInt(),
+    -> true
+
+    else -> false
+}

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapper.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapper.kt
@@ -28,6 +28,7 @@ import com.flxrs.dankchat.data.twitch.message.aliasOrFormattedName
 import com.flxrs.dankchat.data.twitch.message.highestPriorityHighlight
 import com.flxrs.dankchat.data.twitch.message.hypeChatInfo
 import com.flxrs.dankchat.data.twitch.message.isAnimatedMessage
+import com.flxrs.dankchat.data.twitch.message.isAsciiArt
 import com.flxrs.dankchat.data.twitch.message.isElevatedMessage
 import com.flxrs.dankchat.data.twitch.message.isGigantifiedEmote
 import com.flxrs.dankchat.data.twitch.message.recipientAliasOrFormattedName
@@ -676,6 +677,7 @@ class ChatMessageMapper(
             links = findLinks(message).toImmutableList(),
             emotes = emoteUis,
             isAction = isAction,
+            isAsciiArt = originalMessage.isAsciiArt(),
             thread = threadUi,
             highlightHeader = highlightHeader,
             highlightHeaderImageUrl = rewardImageUrl,
@@ -815,6 +817,7 @@ class ChatMessageMapper(
             message = message,
             links = findLinks(message).toImmutableList(),
             emotes = emoteUis,
+            isAsciiArt = originalMessage.isAsciiArt(),
             fullMessage = fullMessage,
             replyTargetName = if (currentUserName != null && name.value.equals(currentUserName.value, ignoreCase = true)) recipientName else name,
         )

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageUiState.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageUiState.kt
@@ -51,6 +51,7 @@ sealed interface ChatMessageUiState {
         val links: ImmutableList<LinkUi>,
         val emotes: ImmutableList<EmoteUi>,
         val isAction: Boolean,
+        val isAsciiArt: Boolean = false,
         val thread: ThreadUi?,
         val highlightHeader: TextResource? = null,
         val highlightHeaderImageUrl: String? = null,
@@ -227,6 +228,7 @@ sealed interface ChatMessageUiState {
         val message: String,
         val links: ImmutableList<LinkUi>,
         val emotes: ImmutableList<EmoteUi>,
+        val isAsciiArt: Boolean = false,
         val fullMessage: String,
         val replyTargetName: UserName,
     ) : ChatMessageUiState

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/PrivMessage.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/PrivMessage.kt
@@ -330,6 +330,7 @@ private fun PrivMessageText(
         emotes = message.emotes,
         fontSize = fontSize,
         animateGifs = animateGifs,
+        isAsciiArt = message.isAsciiArt,
         interactionSource = interactionSource,
         onEmoteClick = onEmoteClick,
         onTextClick = { offset ->

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/WhisperAndRedemption.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/WhisperAndRedemption.kt
@@ -213,6 +213,7 @@ private fun WhisperMessageText(
         emotes = message.emotes,
         fontSize = fontSize,
         animateGifs = animateGifs,
+        isAsciiArt = message.isAsciiArt,
         onEmoteClick = onEmoteClick,
         onTextClick = { offset ->
             val user = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/MessageTextRenderer.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/MessageTextRenderer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +22,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
@@ -50,6 +52,7 @@ fun MessageTextWithInlineContent(
     onTextClick: (Int) -> Unit,
     onEmoteClick: (List<EmoteSheetData>) -> Unit,
     modifier: Modifier = Modifier,
+    isAsciiArt: Boolean = false,
     onTextLongClick: ((Int) -> Unit)? = null,
     interactionSource: MutableInteractionSource? = null,
 ) {
@@ -134,12 +137,18 @@ fun MessageTextWithInlineContent(
         inlineContentProviders = inlineContentProviders,
         style = TextStyle(fontSize = fontSize.sp),
         knownDimensions = knownDimensions,
-        modifier = modifier.fillMaxWidth(),
+        modifier =
+            modifier
+                .then(if (isAsciiArt) Modifier.widthIn(max = ASCII_ART_MAX_WIDTH) else Modifier)
+                .fillMaxWidth(),
         interactionSource = interactionSource,
         onTextClick = onTextClick,
         onTextLongClick = onTextLongClick,
     )
 }
+
+// Compose's density-independent pixels match the logical CSS-pixel chat width.
+private val ASCII_ART_MAX_WIDTH = 300.dp
 
 private fun EmoteUi.dimensionKey(baseHeightPx: Int): String = when {
     urls.size == 1 -> singleEmoteCacheKey(urls.first(), baseHeightPx)

--- a/app/src/test/kotlin/com/flxrs/dankchat/data/twitch/message/AsciiArtTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/data/twitch/message/AsciiArtTest.kt
@@ -1,0 +1,38 @@
+package com.flxrs.dankchat.data.twitch.message
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class AsciiArtTest {
+    @Test
+    fun `rejects ambiguous messages`() {
+        assertFalse("ordinary prose ⣿⣿⣿".isAsciiArt())
+
+        val modifiedHand = "👉🏿"
+        assertFalse((modifiedHand.repeat(10) + " " + modifiedHand.repeat(10)).isAsciiArt())
+    }
+
+    @Test
+    fun `detects mixed Unicode art`() {
+        val longText = "x".repeat(200)
+
+        assertTrue((BRAILLE_SEGMENT + BRAILLE_SEGMENT).isAsciiArt())
+        assertTrue((BLOCK_SEGMENT + " " + longText + " " + BLOCK_SEGMENT).isAsciiArt())
+
+        val rowWithBrailleBlank = BRAILLE_SEGMENT + "⠀" + BRAILLE_SEGMENT
+        assertTrue((BRAILLE_SEGMENT + " mixed text " + rowWithBrailleBlank).isAsciiArt())
+    }
+
+    @Test
+    fun `detects emoji art by grapheme`() {
+        val modifiedHand = "👉🏿"
+
+        assertTrue((modifiedHand.repeat(20) + " " + modifiedHand.repeat(20)).isAsciiArt())
+    }
+
+    private companion object {
+        const val BRAILLE_SEGMENT = "⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿"
+        const val BLOCK_SEGMENT = "▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"
+    }
+}


### PR DESCRIPTION
limit the width of messages containing ascii art to match twitch web chat (300dp) so that they display as intended

a message is classified as ascii art if it contains 40 or more graphemes with code points in the `So` or `Sk` categories

screenshots:

<details> <summary>before</summary>

<br>

<img src="https://github.com/user-attachments/assets/47123b77-2622-4bc1-8ceb-2f78cd090022" alt="Before — portrait" width="300">

<br><br>

<img src="https://github.com/user-attachments/assets/fdc8f059-8205-447b-be20-8a171eb1bae7" alt="Before — landscape" width="700">

</details>

<details> <summary>after</summary>

<br>

<img src="https://github.com/user-attachments/assets/327b6b0b-b386-40b8-9e2f-4a0991e8e620" alt="After — portrait" width="300">

<br><br>

<img src="https://github.com/user-attachments/assets/6feafbc3-39cf-4d0b-babb-6a45a2c4b63a" alt="After — landscape" width="700">

</details>
