### PR TITLE
feat: add shortcut to reply to last whisper

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/chat/ChatEventProcessor.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/chat/ChatEventProcessor.kt
@@ -94,6 +94,8 @@ class ChatEventProcessor(
     private val scope = CoroutineScope(SupervisorJob() + dispatchersProvider.default)
     private val _lastMessages = MutableStateFlow<PersistentMap<UserName, PersistentList<LastMessage>>>(persistentMapOf())
     internal val lastMessagesFlow: StateFlow<PersistentMap<UserName, PersistentList<LastMessage>>> = _lastMessages.asStateFlow()
+    private val _lastReceivedWhisperUser = MutableStateFlow<UserName?>(null)
+    internal val lastReceivedWhisperUser: StateFlow<UserName?> = _lastReceivedWhisperUser.asStateFlow()
     private val knownRewards = ConcurrentHashMap<String, PubSubMessage.PointRedemption>()
     private val knownAutomodHeldIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
     private val rewardMutex = Mutex()
@@ -458,6 +460,7 @@ class ChatEventProcessor(
         }
 
         val item = ChatItem(message, isMentionTab = true)
+        _lastReceivedWhisperUser.value = message.name
         chatNotificationRepository.addWhisper(item)
         chatNotificationRepository.incrementMentionCount(WhisperMessage.WHISPER_CHANNEL, 1)
         chatNotificationRepository.emitMessages(listOf(item))

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/chat/ChatRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/chat/ChatRepository.kt
@@ -118,6 +118,8 @@ class ChatRepository(
 
     fun getRecentMessages(): ImmutableList<String> = chatEventProcessor.getRecentMessagesForDisplay(chatChannelProvider.activeChannel.value)
 
+    internal val lastReceivedWhisperUser get() = chatEventProcessor.lastReceivedWhisperUser
+
     internal val lastMessagesFlow get() = chatEventProcessor.lastMessagesFlow
 
     fun appendLastMessage(

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/command/CommandRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/command/CommandRepository.kt
@@ -63,10 +63,11 @@ class CommandRepository(
 
     private val defaultCommands = Command.entries
     private val defaultCommandTriggers = defaultCommands.map { it.trigger }
+    private val commandShortcutTriggers = CommandShortcut.entries.map { it.trigger }
 
     private val commandTriggers =
         chatSettingsDataStore.commands.map { customCommands ->
-            defaultCommandTriggers + TwitchCommandRepository.ALL_COMMAND_TRIGGERS + customCommands.map(CustomCommand::trigger)
+            defaultCommandTriggers + commandShortcutTriggers + TwitchCommandRepository.ALL_COMMAND_TRIGGERS + customCommands.map(CustomCommand::trigger)
         }
 
     init {
@@ -85,9 +86,10 @@ class CommandRepository(
 
     fun getReservedTriggers(): Set<String> {
         val builtIn = defaultCommandTriggers
+        val shortcuts = commandShortcutTriggers
         val twitch = TwitchCommandRepository.ALL_COMMAND_TRIGGERS
         val supibot = supibotCommands.values.flatMap { it.value }
-        return (builtIn + twitch + supibot).toSet()
+        return (builtIn + shortcuts + twitch + supibot).toSet()
     }
 
     fun getCommandTriggers(channel: UserName): Flow<List<String>> = when (channel) {
@@ -333,6 +335,7 @@ class CommandRepository(
             twitchCommandRepository
                 .getAvailableCommandTriggers(roomState, userState)
                 .plus(defaultCommandTriggers)
+                .plus(commandShortcutTriggers)
                 .joinToString(separator = " ")
 
         return CommandResult.AcceptedWithResponse(TextResource.Res(R.string.cmd_help_response, persistentListOf(commands)))

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/command/CommandShortcut.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/command/CommandShortcut.kt
@@ -1,0 +1,18 @@
+package com.flxrs.dankchat.data.repo.command
+
+import com.flxrs.dankchat.data.UserName
+
+enum class CommandShortcut(
+    val trigger: String,
+) {
+    ReplyToLastWhisper(trigger = "/r"),
+}
+
+internal fun expandReplyToLastWhisper(
+    text: String,
+    lastReceivedWhisperUser: UserName?,
+): String? {
+    val trigger = CommandShortcut.ReplyToLastWhisper.trigger
+    if (lastReceivedWhisperUser == null || !text.startsWith("$trigger ", ignoreCase = true)) return null
+    return "/w ${lastReceivedWhisperUser.value}${text.substring(trigger.length)}"
+}

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputViewModel.kt
@@ -17,6 +17,7 @@ import com.flxrs.dankchat.data.repo.chat.ChatRepository
 import com.flxrs.dankchat.data.repo.chat.UserStateRepository
 import com.flxrs.dankchat.data.repo.command.CommandRepository
 import com.flxrs.dankchat.data.repo.command.CommandResult
+import com.flxrs.dankchat.data.repo.command.expandReplyToLastWhisper
 import com.flxrs.dankchat.data.repo.emote.EmoteRepository
 import com.flxrs.dankchat.data.repo.emote.EmoteUsageRepository
 import com.flxrs.dankchat.data.repo.stream.StreamDataRepository
@@ -198,6 +199,16 @@ class ChatInputViewModel(
                 repeatedSend.update { data -> data.copy(enabled = false) }
                 setReplying(false)
                 _isAnnouncing.value = false
+            }
+        }
+
+        viewModelScope.launch {
+            textFlow.collect { text ->
+                val expanded = expandReplyToLastWhisper(text, chatRepository.lastReceivedWhisperUser.value) ?: return@collect
+                textFieldState.edit {
+                    replace(0, length, expanded)
+                    placeCursorAtEnd()
+                }
             }
         }
 

--- a/app/src/test/kotlin/com/flxrs/dankchat/data/repo/command/CommandShortcutTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/data/repo/command/CommandShortcutTest.kt
@@ -1,0 +1,33 @@
+package com.flxrs.dankchat.data.repo.command
+
+import com.flxrs.dankchat.data.toUserName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class CommandShortcutTest {
+    @Test
+    fun `reply command expands to whisper command`() {
+        assertEquals("/w qbit ", expandReplyToLastWhisper("/r ", "qbit".toUserName()))
+    }
+
+    @Test
+    fun `reply command is case insensitive and preserves message`() {
+        assertEquals("/w qbit hello", expandReplyToLastWhisper("/R hello", "qbit".toUserName()))
+    }
+
+    @Test
+    fun `reply command without a received whisper does not expand`() {
+        assertNull(expandReplyToLastWhisper("/r ", null))
+    }
+
+    @Test
+    fun `reply command does not expand before a space is entered`() {
+        assertNull(expandReplyToLastWhisper("/r", "qbit".toUserName()))
+    }
+
+    @Test
+    fun `reply command does not expand within a message`() {
+        assertNull(expandReplyToLastWhisper("hello /r ", "qbit".toUserName()))
+    }
+}


### PR DESCRIPTION
Adds a `/r` shortcut for replying to the last received whisper.

Typing `/r` followed by a space expands it in the text box to `/w username `, so the recipient is visible before the message is sent. If no whisper has been received, the shortcut does nothing. Any text after `/r ` is preserved during expansion.

Adds `/r` to command suggestions and `/help`. This is missing from the preview video below because I did not want to re-record it.

https://github.com/user-attachments/assets/7162c530-c50d-4682-81c5-bebf66dbc0af