### PR TITLE
fix: focus input when replying to a message

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputLayout.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputLayout.kt
@@ -227,6 +227,12 @@ fun ChatInputLayout(
     val view = LocalView.current
     val inputMethodManager = remember(view) { view.context.getSystemService(InputMethodManager::class.java) }
     val keyboardController = LocalSoftwareKeyboardController.current
+    LaunchedEffect(overlay) {
+        if (overlay is InputOverlay.Reply) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
     var visibleActions by remember { mutableStateOf(effectiveActions) }
     val quickActionsExpanded = overflowExpanded || tourState.forceOverflowOpen
     var showConfigSheet by remember { mutableStateOf(false) }


### PR DESCRIPTION
Fixes an issue identified in #764 

Focus the input box and display the keyboard after clicking "reply to message" from the long-press menu.