### PR TITLE
feat: add multiple channels at once

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreen.kt
@@ -322,8 +322,8 @@ fun MainScreen(
         isStreamActive = currentStream != null,
         inputSheetState = inputSheetState,
         sheetsReady = sheetsReady,
-        onAddChannel = {
-            channelManagementViewModel.addChannel(it)
+        onAddChannels = {
+            channelManagementViewModel.addChannels(it)
             dialogViewModel.dismissAddChannel()
         },
         onLogout = onLogout,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/channel/ChannelManagementViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/channel/ChannelManagementViewModel.kt
@@ -73,13 +73,21 @@ class ChannelManagementViewModel(
     fun isChannelAdded(name: String): Boolean = preferenceStore.channels.any { it.value.equals(name, ignoreCase = true) }
 
     fun addChannel(channel: UserName) {
-        val normalized = channel.lowercase()
+        addChannels(listOf(channel))
+    }
+
+    fun addChannels(channels: List<UserName>) {
         val current = preferenceStore.channels
-        if (normalized !in current) {
-            preferenceStore.channels = current + normalized
-            chatRepository.joinChannel(normalized)
-            chatChannelProvider.setActiveChannel(normalized)
-        }
+        val newChannels =
+            channels
+                .map(UserName::lowercase)
+                .distinct()
+                .filterNot(current::contains)
+        if (newChannels.isEmpty()) return
+
+        preferenceStore.channels = current + newChannels
+        newChannels.forEach(chatRepository::joinChannel)
+        chatChannelProvider.setActiveChannel(newChannels.last())
     }
 
     fun removeChannel(channel: UserName) {

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/AddChannelDialog.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/AddChannelDialog.kt
@@ -10,26 +10,39 @@ import com.flxrs.dankchat.utils.compose.InputBottomSheet
 @Composable
 fun AddChannelDialog(
     onDismiss: () -> Unit,
-    onAddChannel: (UserName) -> Unit,
+    onAddChannels: (List<UserName>) -> Unit,
     isChannelAlreadyAdded: (String) -> Boolean,
 ) {
     val alreadyAddedError = stringResource(R.string.add_channel_already_added)
+    val noChannelsError = stringResource(R.string.add_channels_empty)
     InputBottomSheet(
-        title = stringResource(R.string.add_channel),
-        hint = stringResource(R.string.add_channel_hint),
+        title = stringResource(R.string.add_channels),
+        hint = stringResource(R.string.add_channels_hint),
         capitalization = KeyboardCapitalization.None,
         autoCorrectEnabled = false,
         showClearButton = true,
+        singleLine = false,
         validate = { input ->
+            val channels = parseChannelNames(input)
             when {
-                isChannelAlreadyAdded(input) -> alreadyAddedError
+                input.isNotBlank() && channels.isEmpty() -> noChannelsError
+                channels.isNotEmpty() && channels.all { isChannelAlreadyAdded(it.value) } -> alreadyAddedError
                 else -> null
             }
         },
-        onConfirm = { name ->
-            onAddChannel(UserName(name))
+        onConfirm = { input ->
+            val channels = parseChannelNames(input).filterNot { isChannelAlreadyAdded(it.value) }
+            onAddChannels(channels)
             onDismiss()
         },
         onDismiss = onDismiss,
     )
 }
+
+internal fun parseChannelNames(input: String): List<UserName> = input
+    .split(CHANNEL_NAME_SEPARATOR)
+    .filter(String::isNotBlank)
+    .map(::UserName)
+    .distinctBy { it.value.lowercase() }
+
+private val CHANNEL_NAME_SEPARATOR = "[,\\s]+".toRegex()

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/MainScreenDialogs.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/MainScreenDialogs.kt
@@ -80,7 +80,7 @@ fun MainScreenDialogs(
     isStreamActive: Boolean,
     inputSheetState: InputSheetState,
     sheetsReady: Boolean,
-    onAddChannel: (UserName) -> Unit,
+    onAddChannels: (List<UserName>) -> Unit,
     onLogout: () -> Unit,
     onLogin: () -> Unit,
     onOpenUrl: (String) -> Unit,
@@ -99,7 +99,7 @@ fun MainScreenDialogs(
     if (dialogState.showAddChannel) {
         AddChannelDialog(
             onDismiss = dialogViewModel::dismissAddChannel,
-            onAddChannel = onAddChannel,
+            onAddChannels = onAddChannels,
             isChannelAlreadyAdded = channelManagementViewModel::isChannelAdded,
         )
     }

--- a/app/src/main/kotlin/com/flxrs/dankchat/utils/compose/InputBottomSheet.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/utils/compose/InputBottomSheet.kt
@@ -71,6 +71,8 @@ fun InputBottomSheet(
     capitalization: KeyboardCapitalization = KeyboardCapitalization.Unspecified,
     autoCorrectEnabled: Boolean = true,
     showClearButton: Boolean = false,
+    singleLine: Boolean = true,
+    maxLines: Int = if (singleLine) 1 else 5,
     validate: ((String) -> String?)? = null,
 ) {
     var inputValue by remember { mutableStateOf(TextFieldValue(defaultValue, selection = TextRange(defaultValue.length))) }
@@ -171,7 +173,8 @@ fun InputBottomSheet(
                     value = inputValue,
                     onValueChange = { inputValue = it },
                     label = { Text(hint) },
-                    singleLine = true,
+                    singleLine = singleLine,
+                    maxLines = maxLines,
                     isError = errorText != null,
                     trailingIcon =
                         if (showClearButton && inputValue.text.isNotEmpty()) {
@@ -191,7 +194,7 @@ fun InputBottomSheet(
                             capitalization = capitalization,
                             autoCorrectEnabled = autoCorrectEnabled,
                             keyboardType = keyboardType,
-                            imeAction = ImeAction.Done,
+                            imeAction = if (singleLine) ImeAction.Done else ImeAction.Default,
                         ),
                     keyboardActions =
                         KeyboardActions(onDone = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="error_dialog_copy">Copy</string>
     <string name="error_dialog_title">Caught exception: %1$s</string>
     <string name="add_channel">Add channel</string>
+    <string name="add_channels">Add channels</string>
     <string name="manage_channels">Manage channels</string>
     <string name="report_channel">Report channel</string>
     <string name="block_channel">Block channel</string>
@@ -115,6 +116,8 @@
 
     <string name="snackbar_paste">Paste</string>
     <string name="add_channel_hint">Channel name</string>
+    <string name="add_channels_hint">Channel names</string>
+    <string name="add_channels_empty">Enter at least one channel name</string>
     <string name="add_channel_already_added">Channel is already added</string>
     <string name="emote_menu_tab_recent">Recent</string>
     <string name="backspace">Backspace</string>

--- a/app/src/test/kotlin/com/flxrs/dankchat/ui/main/dialog/AddChannelDialogTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/ui/main/dialog/AddChannelDialogTest.kt
@@ -1,0 +1,25 @@
+package com.flxrs.dankchat.ui.main.dialog
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class AddChannelDialogTest {
+    @Test
+    fun `single channel name is supported`() {
+        assertEquals(listOf("channel"), parseChannelNames("channel").map { it.value })
+    }
+
+    @Test
+    fun `channel names can be separated by whitespace or commas`() {
+        val channels = parseChannelNames("one, two\nthree\tfour")
+
+        assertEquals(listOf("one", "two", "three", "four"), channels.map { it.value })
+    }
+
+    @Test
+    fun `channel names are deduplicated case insensitively`() {
+        val channels = parseChannelNames("One one, TWO two")
+
+        assertEquals(listOf("One", "TWO"), channels.map { it.value })
+    }
+}


### PR DESCRIPTION
Addresses #51 

Allows multiple channels to be added at once from the "Add channels" dialog. Channel names can be separated by whitespace, new lines, or commas. Duplicates are ignored.

https://github.com/user-attachments/assets/ae432954-4c62-4291-bd92-410002ed9658

