### PR TITLE
feat: add conversation notifications

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/notification/NotificationConversationStore.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/notification/NotificationConversationStore.kt
@@ -1,0 +1,91 @@
+package com.flxrs.dankchat.data.notification
+
+import com.flxrs.dankchat.data.UserName
+
+internal class NotificationConversationStore(
+    private val historyLimit: Int,
+) {
+    private val lock = Any()
+    private val channelNotifications = mutableMapOf<UserName, LinkedHashMap<String, NotificationData>>()
+    private val whisperNotifications = mutableMapOf<UserName, WhisperNotificationState>()
+
+    fun addChannelMessage(
+        channel: UserName,
+        data: NotificationData,
+    ) {
+        synchronized(lock) {
+            val messages = channelNotifications.getOrPut(channel) { linkedMapOf() }
+            messages[data.id] = data
+            while (messages.size > historyLimit) {
+                messages.remove(messages.keys.first())
+            }
+        }
+    }
+
+    fun channelMessages(channel: UserName): List<NotificationData> = synchronized(lock) {
+        channelNotifications[channel]
+            ?.values
+            ?.toList()
+            .orEmpty()
+    }
+
+    fun clearChannel(channel: UserName) {
+        synchronized(lock) {
+            channelNotifications.remove(channel)
+        }
+    }
+
+    fun channelKeys(): List<UserName> = synchronized(lock) { channelNotifications.keys.toList() }
+
+    fun addWhisperMessage(
+        key: UserName,
+        target: NotificationData,
+        message: ConversationMessage,
+    ) {
+        synchronized(lock) {
+            val state = whisperNotifications.getOrPut(key) { WhisperNotificationState(target) }
+            state.target = target
+            state.messages.add(message)
+            state.messages.trimHistory()
+        }
+    }
+
+    fun whisper(key: UserName): WhisperNotificationSnapshot? = synchronized(lock) {
+        whisperNotifications[key]?.let { WhisperNotificationSnapshot(it.target, it.messages.toList()) }
+    }
+
+    fun clearWhisper(key: UserName) {
+        synchronized(lock) {
+            whisperNotifications.remove(key)
+        }
+    }
+
+    fun whisperKeys(): List<UserName> = synchronized(lock) { whisperNotifications.keys.toList() }
+
+    private fun MutableList<ConversationMessage>.trimHistory() {
+        while (size > historyLimit) {
+            removeAt(0)
+        }
+    }
+
+    private data class WhisperNotificationState(
+        var target: NotificationData,
+        val messages: MutableList<ConversationMessage> = mutableListOf(),
+    )
+}
+
+internal data class WhisperNotificationSnapshot(
+    val target: NotificationData,
+    val messages: List<ConversationMessage>,
+)
+
+internal data class ConversationMessage(
+    val text: String,
+    val timestamp: Long,
+    val sender: ConversationSender,
+)
+
+internal data class ConversationSender(
+    val name: String,
+    val key: String,
+)

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/notification/NotificationData.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/notification/NotificationData.kt
@@ -1,5 +1,7 @@
 package com.flxrs.dankchat.data.notification
 
+import com.flxrs.dankchat.data.DisplayName
+import com.flxrs.dankchat.data.UserId
 import com.flxrs.dankchat.data.UserName
 import com.flxrs.dankchat.data.twitch.message.Message
 import com.flxrs.dankchat.data.twitch.message.PrivMessage
@@ -7,8 +9,12 @@ import com.flxrs.dankchat.data.twitch.message.WhisperMessage
 import com.flxrs.dankchat.data.twitch.message.shouldNotify
 
 data class NotificationData(
+    val id: String,
+    val timestamp: Long,
     val channel: UserName,
+    val userId: UserId?,
     val name: UserName,
+    val displayName: DisplayName,
     val message: String,
     val isWhisper: Boolean = false,
     val isNotify: Boolean = false,
@@ -21,13 +27,17 @@ fun Message.toNotificationData(): NotificationData? {
 
     return when (this) {
         is PrivMessage -> {
-            NotificationData(channel, name, originalMessage)
+            NotificationData(id, timestamp, channel, userId, name, displayName, originalMessage)
         }
 
         is WhisperMessage -> {
             NotificationData(
+                id = id,
+                timestamp = timestamp,
                 channel = UserName.EMPTY,
+                userId = userId,
                 name = name,
+                displayName = displayName,
                 message = originalMessage,
                 isWhisper = true,
             )

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/notification/NotificationService.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/notification/NotificationService.kt
@@ -5,13 +5,27 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
+import android.graphics.Bitmap
 import android.os.Binder
 import android.os.IBinder
+import android.util.LruCache
 import androidx.core.app.NotificationCompat
+import androidx.core.app.Person
 import androidx.core.app.ServiceCompat
+import androidx.core.content.LocusIdCompat
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import androidx.core.graphics.drawable.toBitmap
+import coil3.asDrawable
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import coil3.size.Size
 import com.flxrs.dankchat.R
 import com.flxrs.dankchat.data.UserName
-import com.flxrs.dankchat.data.repo.chat.ChatChannelProvider
+import com.flxrs.dankchat.data.auth.AuthDataStore
+import com.flxrs.dankchat.data.repo.channel.ChannelRepository
 import com.flxrs.dankchat.data.repo.chat.ChatNotificationRepository
 import com.flxrs.dankchat.data.repo.chat.NotificationClearScope
 import com.flxrs.dankchat.data.repo.data.DataRepository
@@ -23,17 +37,18 @@ import com.flxrs.dankchat.utils.AppLifecycleListener.AppLifecycle
 import com.flxrs.dankchat.utils.ForegroundServiceState
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.ConcurrentSet
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.koin.android.ext.android.inject
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
@@ -46,18 +61,24 @@ class NotificationService :
     private val binder = LocalBinder()
     private val manager: NotificationManager by lazy { getSystemService(NOTIFICATION_SERVICE) as NotificationManager }
 
-    private val notifications = ConcurrentHashMap<UserName, MutableList<Int>>()
+    private val conversationStore = NotificationConversationStore(NotificationCompat.MessagingStyle.MAXIMUM_RETAINED_MESSAGES)
+    private val notificationMutex = Mutex()
     private val notifiedMessageIds: MutableSet<String> = ConcurrentSet()
+    private val notificationIcons = LruCache<String, Bitmap>(MAX_NOTIFICATION_ICONS)
+    private val appIcon: Bitmap by lazy {
+        applicationInfo.loadIcon(packageManager).toBitmap(CONVERSATION_ICON_SIZE, CONVERSATION_ICON_SIZE, Bitmap.Config.ARGB_8888)
+    }
 
+    private val authDataStore: AuthDataStore by inject()
     private val chatNotificationRepository: ChatNotificationRepository by inject()
-    private val chatChannelProvider: ChatChannelProvider by inject()
+    private val channelRepository: ChannelRepository by inject()
     private val dataRepository: DataRepository by inject()
     private val notificationsSettingsDataStore: NotificationsSettingsDataStore by inject()
     private val appLifecycleListener: AppLifecycleListener by inject()
     private val dispatchersProvider: DispatchersProvider by inject()
     private val foregroundServiceState: ForegroundServiceState by inject()
 
-    private val pendingIntentFlag: Int = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    private val immutablePendingIntentFlag = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
 
     private val job = SupervisorJob()
     override val coroutineContext: CoroutineContext
@@ -72,7 +93,6 @@ class NotificationService :
     override fun onDestroy() {
         coroutineContext.cancelChildren()
         manager.cancelAll()
-
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
         super.onDestroy()
@@ -81,15 +101,12 @@ class NotificationService :
     override fun onCreate() {
         super.onCreate()
         val name = getString(R.string.app_name)
-        val channel =
-            NotificationChannel(CHANNEL_ID_LOW, name, NotificationManager.IMPORTANCE_LOW).apply {
-                enableVibration(false)
-                enableLights(false)
-                setShowBadge(false)
-            }
-
-        val mentionChannel = NotificationChannel(CHANNEL_ID_DEFAULT, "Mentions", NotificationManager.IMPORTANCE_DEFAULT)
-        manager.createNotificationChannel(mentionChannel)
+        val channel = NotificationChannel(CHANNEL_ID_LOW, name, NotificationManager.IMPORTANCE_LOW).apply {
+            enableVibration(false)
+            enableLights(false)
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(NotificationChannel(CHANNEL_ID_DEFAULT, "Mentions", NotificationManager.IMPORTANCE_DEFAULT))
         manager.createNotificationChannel(channel)
 
         launch {
@@ -101,51 +118,35 @@ class NotificationService :
                             emptyFlow()
                         }
 
-                        AppLifecycle.Background -> {
-                            combine(
-                                chatNotificationRepository.messageUpdates,
-                                notificationsSettingsDataStore.showNotifications,
-                            ) { items, enabled -> items to enabled }
-                        }
+                        AppLifecycle.Background -> combine(
+                            chatNotificationRepository.messageUpdates,
+                            notificationsSettingsDataStore.showNotifications,
+                        ) { items, enabled -> items to enabled }
                     }
                 }.collect { (items, enabled) ->
-                    if (!enabled) {
-                        return@collect
-                    }
-
+                    if (!enabled) return@collect
                     items.forEach { (message) ->
-                        if (!notifiedMessageIds.add(message.id)) {
-                            return@forEach
-                        }
+                        if (!notifiedMessageIds.add(message.id)) return@forEach
                         if (notifiedMessageIds.size > MAX_NOTIFIED_IDS) {
-                            val iterator = notifiedMessageIds.iterator()
-                            iterator.next()
-                            iterator.remove()
+                            notifiedMessageIds.iterator().run {
+                                next()
+                                remove()
+                            }
                         }
-                        message.toNotificationData()?.createMentionNotification()
+                        message.toNotificationData()?.let { data ->
+                            notificationMutex.withLock { data.createNotification() }
+                        }
                     }
                 }
         }
 
-        // Clear Android notifications when switching channels while the app is in the foreground
-        launch {
-            combine(
-                appLifecycleListener.appState,
-                chatChannelProvider.activeChannel.filterNotNull(),
-            ) { lifecycle, channel -> lifecycle to channel }
-                .collect { (lifecycle, channel) ->
-                    if (lifecycle == AppLifecycle.Foreground) {
-                        clearNotificationsForChannel(channel)
-                    }
-                }
-        }
-
-        // React to UI signals that mention/whisper notifications were viewed.
         launch {
             chatNotificationRepository.notificationClearRequests.collect { scope ->
-                when (scope) {
-                    NotificationClearScope.Mentions -> clearAllMentionNotifications()
-                    NotificationClearScope.Whispers -> clearNotificationsForChannel(UserName.EMPTY)
+                notificationMutex.withLock {
+                    when (scope) {
+                        NotificationClearScope.Mentions -> clearAllMentionNotifications()
+                        NotificationClearScope.Whispers -> clearNotificationsForChannelLocked(UserName.EMPTY)
+                    }
                 }
             }
         }
@@ -158,9 +159,17 @@ class NotificationService :
     ): Int {
         when (intent?.action) {
             STOP_COMMAND -> launch { dataRepository.sendShutdownCommand() }
+
+            DISMISS_CHANNEL_COMMAND -> intent.channelExtra()?.let { channel ->
+                launch { notificationMutex.withLock { clearNotificationsForChannelLocked(channel) } }
+            }
+
+            DISMISS_WHISPER_COMMAND -> intent.userNameExtra()?.let { key ->
+                launch { notificationMutex.withLock { clearWhisperNotification(key) } }
+            }
+
             else -> startForeground()
         }
-
         return START_NOT_STICKY
     }
 
@@ -170,58 +179,55 @@ class NotificationService :
     ) {
         logger.warn { "Stopping foreground service due to 6h timeout restriction.." }
         foregroundServiceState.setActive(false)
-        // stopSelf alone does not stop the service while clients are bound, demote explicitly to satisfy the timeout deadline
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 
     fun clearNotificationsForChannel(channel: UserName) {
-        val ids = notifications.remove(channel)
-        ids?.forEach { manager.cancel(it) }
-
-        if (notifications.isEmpty()) {
-            manager.cancel(SUMMARY_NOTIFICATION_ID)
-            manager.cancelAll()
+        launch {
+            notificationMutex.withLock { clearNotificationsForChannelLocked(channel) }
         }
     }
 
+    private fun clearNotificationsForChannelLocked(channel: UserName) {
+        if (channel == UserName.EMPTY) {
+            conversationStore.whisperKeys().forEach(::clearWhisperNotification)
+            return
+        }
+        conversationStore.clearChannel(channel)
+        manager.cancel(channelTag(channel), CHANNEL_NOTIFICATION_ID)
+    }
+
     private fun clearAllMentionNotifications() {
-        val mentionChannels = notifications.keys.filter { it != UserName.EMPTY }
-        mentionChannels.forEach { clearNotificationsForChannel(it) }
+        conversationStore.channelKeys().forEach(::clearNotificationsForChannelLocked)
     }
 
     private fun startForeground(allowRetry: Boolean = true) {
-        val title = getString(R.string.notification_title)
-        val message = getString(R.string.notification_message)
-
-        val pendingStartActivityIntent =
-            Intent(this, MainActivity::class.java).let {
-                PendingIntent.getActivity(this, NOTIFICATION_START_INTENT_CODE, it, pendingIntentFlag)
-            }
-
-        val pendingStopIntent =
-            Intent(this, NotificationService::class.java).let {
-                it.action = STOP_COMMAND
-                PendingIntent.getService(this, NOTIFICATION_STOP_INTENT_CODE, it, pendingIntentFlag)
-            }
-
-        val notification =
-            NotificationCompat
-                .Builder(this, CHANNEL_ID_LOW)
-                .setSound(null)
-                .setVibrate(null)
-                .setContentTitle(title)
-                .setContentText(message)
-                .addAction(R.drawable.ic_clear, getString(R.string.notification_stop), pendingStopIntent)
-                .setContentIntent(pendingStartActivityIntent)
-                .setSmallIcon(R.drawable.ic_notification_icon)
-                .build()
-
+        val startIntent = PendingIntent.getActivity(
+            this,
+            NOTIFICATION_START_INTENT_CODE,
+            Intent(this, MainActivity::class.java),
+            immutablePendingIntentFlag,
+        )
+        val stopIntent = PendingIntent.getService(
+            this,
+            NOTIFICATION_STOP_INTENT_CODE,
+            Intent(this, NotificationService::class.java).setAction(STOP_COMMAND),
+            immutablePendingIntentFlag,
+        )
+        val notification = NotificationCompat
+            .Builder(this, CHANNEL_ID_LOW)
+            .setSound(null)
+            .setVibrate(null)
+            .setContentTitle(getString(R.string.notification_title))
+            .setContentText(getString(R.string.notification_message))
+            .addAction(R.drawable.ic_clear, getString(R.string.notification_stop), stopIntent)
+            .setContentIntent(startIntent)
+            .setSmallIcon(R.drawable.ic_notification_icon)
+            .build()
         try {
             startForeground(NOTIFICATION_ID, notification)
         } catch (e: IllegalStateException) {
-            // Android 15+ throws when the 6h dataSync budget is exhausted, even on starts racing
-            // the foreground transition.
             logger.warn(e) { "Failed to promote service to foreground" }
             if (allowRetry) {
                 launch {
@@ -232,47 +238,254 @@ class NotificationService :
         }
     }
 
-    private fun NotificationData.createMentionNotification() {
-        val pendingStartActivityIntent =
-            Intent(this@NotificationService, MainActivity::class.java).let {
-                it.putExtra(MainActivity.OPEN_CHANNEL_KEY, channel)
-                PendingIntent.getActivity(this@NotificationService, notificationIntentCode.fetchAndAdd(1), it, pendingIntentFlag)
-            }
-
-        val summary =
-            NotificationCompat
-                .Builder(this@NotificationService, CHANNEL_ID_DEFAULT)
-                .setContentTitle(getString(R.string.notification_new_mentions))
-                .setContentText("")
-                .setSmallIcon(R.drawable.ic_notification_icon)
-                .setGroup(MENTION_GROUP)
-                .setGroupSummary(true)
-                .setAutoCancel(true)
-                .build()
-
-        val title =
-            when {
-                isWhisper -> getString(R.string.notification_whisper_mention, name)
-                isNotify -> getString(R.string.notification_notify_mention, channel)
-                else -> getString(R.string.notification_mention, name, channel)
-            }
-
-        val notification =
-            NotificationCompat
-                .Builder(this@NotificationService, CHANNEL_ID_DEFAULT)
-                .setContentTitle(title)
-                .setContentText(message)
-                .setContentIntent(pendingStartActivityIntent)
-                .setSmallIcon(R.drawable.ic_notification_icon)
-                .setGroup(MENTION_GROUP)
-                .build()
-
-        val id = notificationId.fetchAndAdd(1)
-        notifications.getOrPut(channel) { mutableListOf() } += id
-
-        manager.notify(id, notification)
-        manager.notify(SUMMARY_NOTIFICATION_ID, summary)
+    private suspend fun NotificationData.createNotification() {
+        if (isWhisper) createWhisperNotification() else createChannelNotification()
     }
+
+    private suspend fun NotificationData.createChannelNotification() {
+        conversationStore.addChannelMessage(channel, this)
+        updateChannelNotification(channel)
+    }
+
+    private suspend fun updateChannelNotification(channel: UserName) {
+        val messages = conversationStore.channelMessages(channel)
+        if (messages.isEmpty()) {
+            manager.cancel(channelTag(channel), CHANNEL_NOTIFICATION_ID)
+            return
+        }
+        val latest = messages.last()
+        val channelIcon = latest.channelIcon()
+        val messagesWithSenders = messages.map { it to it.senderPerson(it.senderIcon()) }
+        val shortcutId = channelShortcutId(channel)
+        publishShortcut(shortcutId, "#$channel", messagesWithSenders.map { it.second }.distinctBy { it.key }, openChannelIntent(channel), channelIcon)
+        val style = NotificationCompat
+            .MessagingStyle(currentUserPerson())
+            .setConversationTitle("#$channel")
+            .setGroupConversation(true)
+        messagesWithSenders.forEach { (message, sender) -> style.addMessage(message.message, message.timestamp, sender) }
+        val notification = NotificationCompat
+            .Builder(this, CHANNEL_ID_DEFAULT)
+            .setContentTitle("#$channel")
+            .setContentText(
+                getString(R.string.notification_message_with_sender, latest.sender().name, latest.message),
+            ).setContentIntent(openChannelPendingIntent(latest, includeMessage = true))
+            .setDeleteIntent(dismissChannelPendingIntent(channel))
+            .setSmallIcon(R.drawable.ic_notification_icon)
+            .setLargeIcon(channelIcon)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            .setShortcutId(shortcutId)
+            .setLocusId(LocusIdCompat(shortcutId))
+            .setStyle(style)
+            .setAutoCancel(true)
+            .build()
+        manager.notify(channelTag(channel), CHANNEL_NOTIFICATION_ID, notification)
+    }
+
+    private suspend fun NotificationData.createWhisperNotification() {
+        val key = name.lowercase()
+        conversationStore.addWhisperMessage(key, this, ConversationMessage(message, timestamp, sender()))
+        updateWhisperNotification(key, senderIcon())
+    }
+
+    private suspend fun updateWhisperNotification(
+        key: UserName,
+        icon: Bitmap? = null,
+    ) {
+        val state = conversationStore.whisper(key) ?: return
+        val target = state.target
+        val conversationIcon = icon ?: target.senderIcon()
+        val shortcutId = whisperShortcutId(target)
+        val conversationTitle = getString(R.string.notification_whisper_conversation_title, target.displayName.value)
+        publishShortcut(shortcutId, conversationTitle, listOf(target.senderPerson(conversationIcon)), openWhisperIntent(target.name), conversationIcon)
+        val currentUser = currentUserSender()
+        val currentUserIcon = currentUserIcon()
+        val style = NotificationCompat
+            .MessagingStyle(currentUser.toPerson(currentUserIcon))
+            .setConversationTitle(conversationTitle)
+            .setGroupConversation(true)
+        val targetKey = target.sender().key
+        state.messages.forEach { message ->
+            val senderIcon = when (message.sender.key) {
+                targetKey -> conversationIcon
+                currentUser.key -> currentUserIcon
+                else -> null
+            }
+            style.addMessage(message.text, message.timestamp, message.sender.toPerson(senderIcon))
+        }
+        val builder = NotificationCompat
+            .Builder(this, CHANNEL_ID_DEFAULT)
+            .setContentTitle(getString(R.string.notification_whisper_mention, target.name))
+            .setContentText(state.messages.last().text)
+            .setSubText(getString(R.string.whispers))
+            .setContentIntent(openWhisperPendingIntent(target.name))
+            .setDeleteIntent(dismissWhisperPendingIntent(key))
+            .setSmallIcon(R.drawable.ic_notification_icon)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            .setShortcutId(shortcutId)
+            .setLocusId(LocusIdCompat(shortcutId))
+            .setStyle(style)
+            .setAutoCancel(true)
+        manager.notify(whisperTag(key), WHISPER_NOTIFICATION_ID, builder.build())
+    }
+
+    private fun clearWhisperNotification(key: UserName) {
+        conversationStore.clearWhisper(key)
+        manager.cancel(whisperTag(key), WHISPER_NOTIFICATION_ID)
+    }
+
+    private fun publishShortcut(
+        id: String,
+        label: String,
+        people: List<Person>,
+        intent: Intent,
+        icon: Bitmap,
+    ) {
+        runCatching {
+            val shortcut = ShortcutInfoCompat
+                .Builder(this, id)
+                .setShortLabel(label)
+                .setLongLabel(label)
+                .setIcon(IconCompat.createWithBitmap(icon))
+                .setIntent(intent)
+                .setPersons(people.toTypedArray())
+                .setIsConversation()
+                .build()
+            if (!ShortcutManagerCompat.pushDynamicShortcut(this, shortcut)) {
+                logger.warn { "Failed to publish conversation shortcut: $id" }
+            }
+        }.onFailure { logger.warn(it) { "Failed to publish conversation shortcut: $id" } }
+    }
+
+    private suspend fun NotificationData.channelIcon(): Bitmap = loadNotificationIcon("channel:${channel.value}") {
+        channelRepository.getUserDtoByName(channel)?.avatarUrl
+    }
+
+    private suspend fun NotificationData.senderIcon(): Bitmap = loadNotificationIcon("user:${userId?.value ?: name.value}") {
+        userId?.let { channelRepository.getUserDto(it) }?.avatarUrl
+            ?: channelRepository.getUserDtoByName(name)?.avatarUrl
+    }
+
+    private suspend fun loadNotificationIcon(
+        cacheKey: String,
+        findUrl: suspend () -> String?,
+    ): Bitmap {
+        notificationIcons[cacheKey]?.let { return it }
+        val url = try {
+            findUrl()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to find profile image for notification" }
+            null
+        }
+        if (url.isNullOrBlank()) return appIcon
+
+        return try {
+            val request = ImageRequest
+                .Builder(this@NotificationService)
+                .data(url)
+                .allowHardware(false)
+                .size(Size(CONVERSATION_ICON_SIZE, CONVERSATION_ICON_SIZE))
+                .build()
+            imageLoader
+                .execute(request)
+                .image
+                ?.asDrawable(resources)
+                ?.toBitmap(CONVERSATION_ICON_SIZE, CONVERSATION_ICON_SIZE, Bitmap.Config.ARGB_8888)
+                ?.also { notificationIcons.put(cacheKey, it) }
+                ?: appIcon
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to load profile image for notification" }
+            appIcon
+        }
+    }
+
+    private fun NotificationData.sender() = ConversationSender(
+        name = name.formatWithDisplayName(displayName),
+        key = userId?.value ?: name.value,
+    )
+
+    private fun NotificationData.senderPerson(icon: Bitmap? = null): Person = sender().toPerson(icon)
+
+    private fun currentUserSender() = ConversationSender(
+        name = authDataStore.displayName?.value ?: authDataStore.userName?.value ?: getString(R.string.app_name),
+        key = authDataStore.userIdString?.value ?: authDataStore.userName?.value ?: "self",
+    )
+
+    private suspend fun currentUserIcon(): Bitmap = loadNotificationIcon("user:${currentUserSender().key}") {
+        authDataStore.userIdString?.let { channelRepository.getUserDto(it) }?.avatarUrl
+            ?: authDataStore.userName?.let { channelRepository.getUserDtoByName(it) }?.avatarUrl
+    }
+
+    private suspend fun currentUserPerson(): Person = currentUserSender().toPerson(currentUserIcon())
+
+    private fun ConversationSender.toPerson(icon: Bitmap? = null): Person = Person
+        .Builder()
+        .setName(name)
+        .setKey(key)
+        .apply { icon?.let { setIcon(IconCompat.createWithBitmap(it)) } }
+        .build()
+
+    private fun openChannelPendingIntent(
+        data: NotificationData,
+        includeMessage: Boolean,
+    ): PendingIntent = PendingIntent.getActivity(
+        this,
+        notificationIntentCode.fetchAndAdd(1),
+        openChannelIntent(data.channel).apply {
+            if (includeMessage) putExtra(MainActivity.OPEN_MESSAGE_KEY, data.id)
+        },
+        immutablePendingIntentFlag,
+    )
+
+    private fun openWhisperPendingIntent(target: UserName): PendingIntent = PendingIntent.getActivity(
+        this,
+        notificationIntentCode.fetchAndAdd(1),
+        openWhisperIntent(target),
+        immutablePendingIntentFlag,
+    )
+
+    private fun openChannelIntent(channel: UserName): Intent = Intent(this, MainActivity::class.java).apply {
+        action = Intent.ACTION_VIEW
+        putExtra(MainActivity.OPEN_CHANNEL_KEY, channel.value)
+    }
+
+    private fun openWhisperIntent(target: UserName): Intent = openChannelIntent(UserName.EMPTY).apply {
+        putExtra(MainActivity.OPEN_WHISPER_TARGET_KEY, target.value)
+    }
+
+    private fun dismissChannelPendingIntent(channel: UserName): PendingIntent = servicePendingIntent(DISMISS_CHANNEL_COMMAND) { putExtra(EXTRA_CHANNEL, channel) }
+
+    private fun dismissWhisperPendingIntent(key: UserName): PendingIntent = servicePendingIntent(DISMISS_WHISPER_COMMAND) { putExtra(EXTRA_USER_NAME, key) }
+
+    private fun servicePendingIntent(
+        command: String,
+        configure: Intent.() -> Unit,
+    ): PendingIntent = PendingIntent.getService(
+        this,
+        notificationIntentCode.fetchAndAdd(1),
+        Intent(this, NotificationService::class.java).apply {
+            action = command
+            configure()
+        },
+        immutablePendingIntentFlag,
+    )
+
+    @Suppress("DEPRECATION")
+    private fun Intent.channelExtra(): UserName? = getParcelableExtra(EXTRA_CHANNEL)
+
+    @Suppress("DEPRECATION")
+    private fun Intent.userNameExtra(): UserName? = getParcelableExtra(EXTRA_USER_NAME)
+
+    private fun channelTag(channel: UserName) = "channel_${channel.value}"
+
+    private fun whisperTag(key: UserName) = "whisper_${key.value}"
+
+    private fun channelShortcutId(channel: UserName) = "channel_${channel.value}"
+
+    private fun whisperShortcutId(data: NotificationData) = "whisper_${data.userId?.value ?: data.name.value}"
 
     companion object {
         private const val CHANNEL_ID_LOW = "com.flxrs.dankchat.dank_id"
@@ -280,14 +493,20 @@ class NotificationService :
         private const val NOTIFICATION_ID = 77777
         private const val NOTIFICATION_START_INTENT_CODE = 66666
         private const val NOTIFICATION_STOP_INTENT_CODE = 55555
-        private const val SUMMARY_NOTIFICATION_ID = 12345
-        private const val MENTION_GROUP = "dank_group"
+        private const val CHANNEL_NOTIFICATION_ID = 12345
+        private const val WHISPER_NOTIFICATION_ID = 23456
+
         private const val STOP_COMMAND = "STOP_DANKING"
+        private const val DISMISS_CHANNEL_COMMAND = "com.flxrs.dankchat.notification.DISMISS_CHANNEL"
+        private const val DISMISS_WHISPER_COMMAND = "com.flxrs.dankchat.notification.DISMISS_WHISPER"
+
+        private const val EXTRA_CHANNEL = "notification_channel"
+        private const val EXTRA_USER_NAME = "notification_user_name"
 
         private const val MAX_NOTIFIED_IDS = 500
+        private const val MAX_NOTIFICATION_ICONS = 100
+        private const val CONVERSATION_ICON_SIZE = 128
         private val FOREGROUND_RETRY_DELAY = 5.seconds
-
-        private val notificationId = AtomicInt(42)
         private val notificationIntentCode = AtomicInt(420)
     }
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainActivity.kt
@@ -54,6 +54,7 @@ import com.flxrs.dankchat.data.notification.ChatTTSPlayer
 import com.flxrs.dankchat.data.notification.NotificationService
 import com.flxrs.dankchat.data.repo.data.DataRepository
 import com.flxrs.dankchat.data.repo.data.ServiceEvent
+import com.flxrs.dankchat.data.toUserName
 import com.flxrs.dankchat.di.DispatchersProvider
 import com.flxrs.dankchat.preferences.DankChatPreferenceStore
 import com.flxrs.dankchat.preferences.about.AboutScreen
@@ -174,9 +175,7 @@ class MainActivity : ComponentActivity() {
 
         chatTTSPlayer.start()
         setupComposeUi()
-        intent.parcelable<UserName>(OPEN_CHANNEL_KEY)?.let { channel ->
-            lifecycleScope.launch { mainEventBus.emitEvent(MainEvent.OpenChannel(channel)) }
-        }
+        emitNotificationTarget(intent)
 
         viewModel.checkLogin()
         viewModel.serviceEvents
@@ -569,9 +568,19 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        val channelExtra = intent.parcelable<UserName>(OPEN_CHANNEL_KEY) ?: return
-        lifecycleScope.launch { mainEventBus.emitEvent(MainEvent.OpenChannel(channelExtra)) }
+        emitNotificationTarget(intent)
     }
+
+    private fun emitNotificationTarget(intent: Intent) {
+        val channel = intent.userNameExtra(OPEN_CHANNEL_KEY) ?: return
+        val messageId = intent.getStringExtra(OPEN_MESSAGE_KEY)
+        val whisperTarget = intent.userNameExtra(OPEN_WHISPER_TARGET_KEY)
+        lifecycleScope.launch {
+            mainEventBus.emitEvent(MainEvent.OpenChannel(channel, messageId, whisperTarget))
+        }
+    }
+
+    private fun Intent.userNameExtra(key: String): UserName? = parcelable<UserName>(key) ?: getStringExtra(key)?.toUserName()
 
     fun clearNotificationsOfChannel(channel: UserName) {
         notificationService?.clearNotificationsForChannel(channel)
@@ -669,5 +678,7 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         const val OPEN_CHANNEL_KEY = "open_channel"
+        const val OPEN_MESSAGE_KEY = "open_message"
+        const val OPEN_WHISPER_TARGET_KEY = "open_whisper_target"
     }
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainEvent.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainEvent.kt
@@ -24,6 +24,8 @@ sealed interface MainEvent {
 
     data class OpenChannel(
         val channel: UserName,
+        val messageId: String? = null,
+        val whisperTarget: UserName? = null,
     ) : MainEvent
 
     data class MessageCopied(

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreen.kt
@@ -1,6 +1,7 @@
 package com.flxrs.dankchat.ui.main
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -52,7 +53,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.core.layout.WindowSizeClass
 import com.flxrs.dankchat.R
 import com.flxrs.dankchat.data.UserName
@@ -278,6 +282,15 @@ fun MainScreen(
         sheetsReady = true
     }
 
+    val jumpToMessage: (String, UserName) -> Boolean = { messageId, channel ->
+        val target = channelPagerViewModel.resolveJumpTarget(channel, messageId)
+        if (target != null) {
+            scrollTargets[target.channel] = target.messageId
+            scope.launch { composePagerStateRef?.scrollToPage(target.channelIndex) }
+        }
+        target != null
+    }
+
     MainScreenEventHandler(
         snackbarHostState = snackbarHostState,
         mainEventBus = mainEventBus,
@@ -287,10 +300,21 @@ fun MainScreen(
         sheetNavigationViewModel = sheetNavigationViewModel,
         mainScreenViewModel = mainScreenViewModel,
         preferenceStore = preferenceStore,
+        onJumpToMessage = jumpToMessage,
     )
 
     val tabState = channelTabViewModel.uiState.collectAsStateWithLifecycle().value
     val activeChannel = tabState.tabs.getOrNull(tabState.selectedIndex)?.channel
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val activity = LocalActivity.current as? MainActivity
+
+    LaunchedEffect(lifecycleOwner, activeChannel, fullScreenSheetState) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            if (fullScreenSheetState is FullScreenSheetState.Closed) {
+                activeChannel?.let { activity?.clearNotificationsOfChannel(it) }
+            }
+        }
+    }
 
     // Same key as in ChatComposable, so this resolves the active page's instance
     val activePinnedMessageViewModel =
@@ -331,12 +355,9 @@ fun MainScreen(
         onOpenUrl = onOpenUrl,
         onOpenLogViewer = onOpenLogViewer,
         onJumpToMessage = { messageId, channel ->
-            val target = channelPagerViewModel.resolveJumpTarget(channel, messageId)
-            if (target != null) {
+            if (jumpToMessage(messageId, channel)) {
                 messageOptionsViewModel.dismiss()
                 sheetNavigationViewModel.closeFullScreenSheet()
-                scrollTargets[target.channel] = target.messageId
-                scope.launch { composePagerStateRef?.scrollToPage(target.channelIndex) }
             } else {
                 scope.launch {
                     snackbarHostState.showSnackbar(messageNotInHistoryMsg)

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreenEventHandler.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreenEventHandler.kt
@@ -38,6 +38,7 @@ fun MainScreenEventHandler(
     sheetNavigationViewModel: SheetNavigationViewModel,
     mainScreenViewModel: MainScreenViewModel,
     preferenceStore: DankChatPreferenceStore,
+    onJumpToMessage: (messageId: String, channel: UserName) -> Boolean,
 ) {
     val context = LocalContext.current
     val resources = LocalResources.current
@@ -111,10 +112,15 @@ fun MainScreenEventHandler(
                 is MainEvent.OpenChannel -> {
                     if (event.channel == UserName.EMPTY) {
                         sheetNavigationViewModel.openWhispers()
+                        chatInputViewModel.setWhisperTarget(event.whisperTarget)
                     } else {
-                        channelTabViewModel.selectTab(
-                            preferenceStore.channels.indexOf(event.channel),
-                        )
+                        sheetNavigationViewModel.closeFullScreenSheet()
+                        val jumped = event.messageId?.let { onJumpToMessage(it, event.channel) } == true
+                        if (!jumped) {
+                            channelTabViewModel.selectTab(
+                                preferenceStore.channels.indexOf(event.channel),
+                            )
+                        }
                     }
                     (context as? MainActivity)?.clearNotificationsOfChannel(event.channel)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="hint_replying">Reply</string>
     <string name="hint_announcing">Send announcement</string>
     <string name="notification_new_mentions">You have new mentions</string>
+    <string name="notification_channel_mentions">Mentions in #%1$s</string>
+    <string name="notification_message_with_sender">%1$s: %2$s</string>
     <string name="notification_mention">%1$s just mentioned you in #%2$s</string>
     <string name="notification_notify_mention">You were mentioned in #%1$s</string>
     <string name="snackbar_login">Logging in as %1$s</string>
@@ -270,6 +272,7 @@
     <string name="replies_title">Reply Thread</string>
     <string name="whispers">Whispers</string>
     <string name="notification_whisper_mention">%1$s sent you a whisper</string>
+    <string name="notification_whisper_conversation_title">Whisper from @%1$s</string>
     <string name="mentions">Mentions</string>
     <string name="confirm_channel_removal_title">Confirm channel removal</string>
     <string name="confirm_channel_removal_message">Are you sure you want to remove this channel?</string>

--- a/app/src/test/kotlin/com/flxrs/dankchat/data/notification/NotificationConversationStoreTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/data/notification/NotificationConversationStoreTest.kt
@@ -1,0 +1,80 @@
+package com.flxrs.dankchat.data.notification
+
+import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.data.toDisplayName
+import com.flxrs.dankchat.data.toUserName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class NotificationConversationStoreTest {
+    @Test
+    fun `channel notifications retain only the latest messages`() {
+        val store = NotificationConversationStore(historyLimit = 2)
+        val channel = "channel".toUserName()
+
+        (1..3).forEach { id -> store.addChannelMessage(channel, notificationData(id)) }
+
+        assertEquals(listOf("2", "3"), store.channelMessages(channel).map(NotificationData::id))
+    }
+
+    @Test
+    fun `clearing one channel preserves other channels`() {
+        val store = NotificationConversationStore(historyLimit = 25)
+        val first = "first".toUserName()
+        val second = "second".toUserName()
+        store.addChannelMessage(first, notificationData(1, first))
+        store.addChannelMessage(second, notificationData(2, second))
+
+        store.clearChannel(first)
+
+        assertEquals(emptyList(), store.channelMessages(first))
+        assertEquals(listOf("2"), store.channelMessages(second).map(NotificationData::id))
+    }
+
+    @Test
+    fun `whisper conversations retain only the latest messages`() {
+        val store = NotificationConversationStore(historyLimit = 2)
+        val sender = "sender".toUserName()
+        val target = notificationData(1)
+
+        store.addWhisperMessage(sender, target, conversationMessage("one"))
+        store.addWhisperMessage(sender, target, conversationMessage("two"))
+        store.addWhisperMessage(sender, target, conversationMessage("three"))
+
+        assertEquals(listOf("two", "three"), store.whisper(sender)?.messages?.map(ConversationMessage::text))
+    }
+
+    @Test
+    fun `clearing one whisper preserves other senders`() {
+        val store = NotificationConversationStore(historyLimit = 25)
+        val first = "first".toUserName()
+        val second = "second".toUserName()
+        store.addWhisperMessage(first, notificationData(1), conversationMessage("one"))
+        store.addWhisperMessage(second, notificationData(2), conversationMessage("two"))
+
+        store.clearWhisper(first)
+
+        assertNull(store.whisper(first))
+        assertEquals(listOf("two"), store.whisper(second)?.messages?.map(ConversationMessage::text))
+    }
+
+    private fun notificationData(
+        id: Int,
+        channel: UserName = "channel".toUserName(),
+    ) = NotificationData(
+        id = id.toString(),
+        timestamp = id.toLong(),
+        channel = channel,
+        userId = null,
+        name = "sender".toUserName(),
+        displayName = "Sender".toDisplayName(),
+        message = "message $id",
+    )
+
+    private fun conversationMessage(text: String) = ConversationMessage(
+        text = text,
+        timestamp = 0L,
+        sender = ConversationSender(name = "Sender", key = "sender"),
+    )
+}


### PR DESCRIPTION
Overhauls notifications to use Android’s Conversations API.

Notifications are per channel and per whisper sender. They show up to the 25 most recent notifications (android cap).

Uses the channel profile picture as the icon per channel, and each sender’s profile picture for individual messages.

Tapping a channel notification opens the channel. Tapping a whisper notification opens the whispers UI with that sender selected.

Notifications are cleared when the corresponding channel or the whispers sheet is visible.

<details><summary>Screenshots</summary>

<img width="300" alt="Screenshot_1" src="https://github.com/user-attachments/assets/02f7dcc6-14f0-4bd4-ab68-370bc43d4c5f" />

<img width="300" alt="Screenshot_2" src="https://github.com/user-attachments/assets/9cd9c666-80e0-4855-8f94-8d17c2671775" />

</details>