### PR TITLE
feat: add message tap actions

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettings.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettings.kt
@@ -16,6 +16,7 @@ data class ChatSettings(
     val customCommands: List<CustomCommand> = emptyList(),
     val animateGifs: Boolean = true,
     val scrollbackLength: Int = 500,
+    val messageTapAction: MessageTapAction = MessageTapAction.DoNothing,
     val showUsernames: Boolean = true,
     val userLongClickBehavior: UserLongClickBehavior = UserLongClickBehavior.MentionsUser,
     val colorizeNicknames: Boolean = true,
@@ -68,6 +69,18 @@ enum class SuggestionType {
 enum class UserLongClickBehavior {
     MentionsUser,
     OpensPopup,
+}
+
+@Serializable
+enum class MessageTapAction {
+    DoNothing,
+    Reply,
+    Mention,
+    Whisper,
+    OpenUserCard,
+    OpenMessageOptions,
+    CopyMessage,
+    CopyFullMessage,
 }
 
 enum class VisibleBadges {

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsDataStore.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsDataStore.kt
@@ -242,6 +242,10 @@ class ChatSettingsDataStore(
         settings
             .map { it.userLongClickBehavior }
             .distinctUntilChanged()
+    val messageTapAction =
+        settings
+            .map { it.messageTapAction }
+            .distinctUntilChanged()
 
     val debouncedScrollBack =
         settings

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsScreen.kt
@@ -139,6 +139,7 @@ private fun ChatSettingsScreen(
             HorizontalDivider(thickness = Dp.Hairline)
             MessagesCategory(
                 scrollbackLength = settings.scrollbackLength,
+                messageTapAction = settings.messageTapAction,
                 showTimedOutMessages = settings.showTimedOutMessages,
                 showTimestamps = settings.showTimestamps,
                 timestampFormat = settings.timestampFormat,
@@ -237,6 +238,7 @@ private fun SuggestionsCategory(
 @Composable
 private fun MessagesCategory(
     scrollbackLength: Int,
+    messageTapAction: MessageTapAction,
     showTimedOutMessages: Boolean,
     showTimestamps: Boolean,
     timestampFormat: String,
@@ -253,6 +255,25 @@ private fun MessagesCategory(
             onDragFinish = { onInteraction(ChatSettingsInteraction.ScrollbackLength(sliderValue.roundToInt())) },
             displayValue = false,
             summary = sliderValue.roundToInt().toString(),
+        )
+        val messageTapEntries =
+            listOf(
+                stringResource(R.string.preference_message_tap_action_do_nothing),
+                stringResource(R.string.preference_message_tap_action_reply),
+                stringResource(R.string.preference_message_tap_action_mention),
+                stringResource(R.string.preference_message_tap_action_whisper),
+                stringResource(R.string.preference_message_tap_action_open_user_card),
+                stringResource(R.string.preference_message_tap_action_open_message_options),
+                stringResource(R.string.preference_message_tap_action_copy_message),
+                stringResource(R.string.preference_message_tap_action_copy_full_message),
+            ).toImmutableList()
+        PreferenceListDialog(
+            title = stringResource(R.string.preference_message_tap_action_title),
+            summary = messageTapEntries[messageTapAction.ordinal],
+            values = MessageTapAction.entries.toImmutableList(),
+            entries = messageTapEntries,
+            selected = messageTapAction,
+            onChange = { onInteraction(ChatSettingsInteraction.MessageTapActionChange(it)) },
         )
         SwitchPreferenceItem(
             title = stringResource(R.string.preference_show_timed_out_messages_title),

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsState.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsState.kt
@@ -28,6 +28,10 @@ sealed interface ChatSettingsInteraction {
         val value: Int,
     ) : ChatSettingsInteraction
 
+    data class MessageTapActionChange(
+        val value: MessageTapAction,
+    ) : ChatSettingsInteraction
+
     data class ShowUsernames(
         val value: Boolean,
     ) : ChatSettingsInteraction
@@ -96,6 +100,7 @@ data class ChatSettingsState(
     val customCommands: ImmutableList<CustomCommand>,
     val animateGifs: Boolean,
     val scrollbackLength: Int,
+    val messageTapAction: MessageTapAction,
     val showUsernames: Boolean,
     val userLongClickBehavior: UserLongClickBehavior,
     val colorizeNicknames: Boolean,

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsViewModel.kt
@@ -53,6 +53,10 @@ class ChatSettingsViewModel(
                     chatSettingsDataStore.update { it.copy(scrollbackLength = interaction.value) }
                 }
 
+                is ChatSettingsInteraction.MessageTapActionChange -> {
+                    chatSettingsDataStore.update { it.copy(messageTapAction = interaction.value) }
+                }
+
                 is ChatSettingsInteraction.ShowUsernames -> {
                     chatSettingsDataStore.update { it.copy(showUsernames = interaction.value) }
                 }
@@ -129,6 +133,7 @@ private fun ChatSettings.toState() = ChatSettingsState(
     customCommands = customCommands.toImmutableList(),
     animateGifs = animateGifs,
     scrollbackLength = scrollbackLength,
+    messageTapAction = messageTapAction,
     showUsernames = showUsernames,
     userLongClickBehavior = userLongClickBehavior,
     colorizeNicknames = colorizeNicknames,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatComposable.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatComposable.kt
@@ -36,9 +36,11 @@ import com.flxrs.dankchat.preferences.chat.UserLongClickBehavior
 import com.flxrs.dankchat.ui.chat.emote.EmoteInfoViewModel
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsParams
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsViewModel
+import com.flxrs.dankchat.ui.chat.message.rememberMessageCopyActions
 import com.flxrs.dankchat.ui.chat.user.UserPopupStateParams
 import com.flxrs.dankchat.ui.chat.user.UserPopupViewModel
 import com.flxrs.dankchat.ui.main.input.ChatInputViewModel
+import com.flxrs.dankchat.ui.main.sheet.SheetNavigationViewModel
 import kotlinx.collections.immutable.ImmutableList
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -87,6 +89,7 @@ fun ChatComposable(
     val userPopupViewModel: UserPopupViewModel = koinViewModel()
     val messageOptionsViewModel: MessageOptionsViewModel = koinViewModel()
     val chatInputViewModel: ChatInputViewModel = koinViewModel()
+    val sheetNavigationViewModel: SheetNavigationViewModel = koinViewModel()
     val chatSettingsDataStore: ChatSettingsDataStore = koinInject()
     val preferenceStore: DankChatPreferenceStore = koinInject()
 
@@ -104,7 +107,70 @@ fun ChatComposable(
     }
     val displaySettings by viewModel.chatDisplaySettings.collectAsStateWithLifecycle()
     val userLongClickBehavior by chatSettingsDataStore.userLongClickBehavior.collectAsStateWithLifecycle(initialValue = UserLongClickBehavior.MentionsUser)
+    val messageTapAction by
+        chatSettingsDataStore.messageTapAction.collectAsStateWithLifecycle(
+            initialValue = chatSettingsDataStore.current().messageTapAction,
+        )
     val isLoggedIn = preferenceStore.isLoggedIn
+    val messageCopyActions = rememberMessageCopyActions()
+    val openUserCard: (String?, String, String, String?, List<BadgeUi>) -> Unit = { userId, userName, displayName, ch, badges ->
+        userPopupViewModel.show(
+            UserPopupStateParams(
+                targetUserId = userId?.let { UserId(it) },
+                targetUserName = UserName(userName),
+                targetDisplayName = DisplayName(displayName),
+                channel = ch?.let { UserName(it) },
+                badges = badges.map { it.badge },
+            ),
+        )
+    }
+    val openMessageOptions: (String, String?, String) -> Unit = { messageId, ch, fullMessage ->
+        messageOptionsViewModel.show(
+            MessageOptionsParams(
+                messageId = messageId,
+                channel = ch?.let { UserName(it) },
+                fullMessage = fullMessage,
+                canModerate = isLoggedIn,
+                canReply = isLoggedIn,
+                canCopy = true,
+            ),
+        )
+    }
+    val whisperUser: (MessageTapContext) -> Unit = { message ->
+        sheetNavigationViewModel.openWhispers()
+        chatInputViewModel.setWhisperTarget(message.userName)
+    }
+    val onMessageTap =
+        messageTapHandler(
+            action = messageTapAction,
+            isLoggedIn = isLoggedIn,
+            operations =
+                MessageTapOperations(
+                    reply = { message ->
+                        if (message.isWhisper) {
+                            whisperUser(message)
+                        } else {
+                            chatInputViewModel.setReplying(true, message.messageId, message.userName, message.message)
+                        }
+                    },
+                    mention = { message -> chatInputViewModel.mentionUser(message.userName, message.displayName) },
+                    whisper = whisperUser,
+                    openUserCard = { message ->
+                        openUserCard(
+                            message.userId?.value,
+                            message.userName.value,
+                            message.displayName.value,
+                            message.channel?.value,
+                            message.badges,
+                        )
+                    },
+                    openMessageOptions = { message ->
+                        openMessageOptions(message.messageId, message.channel?.value, message.fullMessage)
+                    },
+                    copyMessage = messageCopyActions.copyMessage,
+                    copyFullMessage = messageCopyActions.copyFullMessage,
+                ),
+        )
 
     val callbacks =
         ChatScreenCallbacks(
@@ -115,33 +181,15 @@ fun ChatComposable(
                         UserLongClickBehavior.OpensPopup -> isLongPress
                     }
                 if (shouldOpenPopup) {
-                    userPopupViewModel.show(
-                        UserPopupStateParams(
-                            targetUserId = userId?.let { UserId(it) },
-                            targetUserName = UserName(userName),
-                            targetDisplayName = DisplayName(displayName),
-                            channel = ch?.let { UserName(it) },
-                            badges = badges.map { it.badge },
-                        ),
-                    )
+                    openUserCard(userId, userName, displayName, ch, badges)
                 } else {
                     chatInputViewModel.mentionUser(UserName(userName), DisplayName(displayName))
                 }
             },
-            onMessageLongClick = { messageId, ch, fullMessage ->
-                messageOptionsViewModel.show(
-                    MessageOptionsParams(
-                        messageId = messageId,
-                        channel = ch?.let { UserName(it) },
-                        fullMessage = fullMessage,
-                        canModerate = isLoggedIn,
-                        canReply = isLoggedIn,
-                        canCopy = true,
-                    ),
-                )
-            },
+            onMessageLongClick = openMessageOptions,
             onEmoteClick = { emoteInfoViewModel.show(it) },
             onReplyClick = onReplyClick,
+            onMessageTap = onMessageTap,
             onAutomodAllow = { heldMessageId, ch -> viewModel.manageAutomodMessage(heldMessageId, ch, allow = true) },
             onAutomodDeny = { heldMessageId, ch -> viewModel.manageAutomodMessage(heldMessageId, ch, allow = false) },
             onAutomodBanUser = { messageId, ch, fullMessage ->

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapper.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapper.kt
@@ -2,6 +2,7 @@ package com.flxrs.dankchat.ui.chat
 
 import androidx.compose.ui.graphics.Color
 import com.flxrs.dankchat.R
+import com.flxrs.dankchat.data.DisplayName
 import com.flxrs.dankchat.data.UserId
 import com.flxrs.dankchat.data.UserName
 import com.flxrs.dankchat.data.chat.ChatImportance
@@ -796,6 +797,8 @@ class ChatMessageMapper(
         val rawSenderColor = resolveNameColor(userDisplay?.color, color, userId, chatSettings)
         val rawRecipientColor = resolveNameColor(recipientDisplay?.color, recipientColor, recipientId, chatSettings)
 
+        val replyTarget = resolveWhisperReplyTarget(currentUserName)
+
         return ChatMessageUiState.WhisperMessageUi(
             id = id,
             tag = tag,
@@ -816,7 +819,10 @@ class ChatMessageMapper(
             links = findLinks(message).toImmutableList(),
             emotes = emoteUis,
             fullMessage = fullMessage,
-            replyTargetName = if (currentUserName != null && name.value.equals(currentUserName.value, ignoreCase = true)) recipientName else name,
+            replyTargetName = replyTarget.userName,
+            replyTargetUserId = replyTarget.userId,
+            replyTargetDisplayName = replyTarget.displayName,
+            replyTargetBadges = if (replyTarget.isOutgoing) persistentListOf() else badgeUis,
         )
     }
 
@@ -1037,6 +1043,23 @@ class ChatMessageMapper(
         private val CHECKERED_LIGHT = Color(android.graphics.Color.argb(CHECKERED_ALPHA, 0, 0, 0))
         private val CHECKERED_DARK = Color(android.graphics.Color.argb(CHECKERED_ALPHA, 255, 255, 255))
     }
+}
+
+internal data class WhisperReplyTarget(
+    val userId: UserId?,
+    val userName: UserName,
+    val displayName: DisplayName,
+    val isOutgoing: Boolean,
+)
+
+internal fun WhisperMessage.resolveWhisperReplyTarget(currentUserName: UserName?): WhisperReplyTarget {
+    val isOutgoing = currentUserName != null && name.value.equals(currentUserName.value, ignoreCase = true)
+    return WhisperReplyTarget(
+        userId = if (isOutgoing) recipientId else userId,
+        userName = if (isOutgoing) recipientName else name,
+        displayName = if (isOutgoing) recipientDisplayName else displayName,
+        isOutgoing = isOutgoing,
+    )
 }
 
 private fun ChatMessageUiState.hasSameHighlightBackground(other: ChatMessageUiState?): Boolean = other != null &&

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageUiState.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageUiState.kt
@@ -229,6 +229,9 @@ sealed interface ChatMessageUiState {
         val emotes: ImmutableList<EmoteUi>,
         val fullMessage: String,
         val replyTargetName: UserName,
+        val replyTargetUserId: UserId?,
+        val replyTargetDisplayName: DisplayName,
+        val replyTargetBadges: ImmutableList<BadgeUi>,
     ) : ChatMessageUiState
 }
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatScreen.kt
@@ -111,6 +111,7 @@ data class ChatScreenCallbacks(
     val onMessageLongClick: (messageId: String, channel: String?, fullMessage: String) -> Unit,
     val onEmoteClick: (emotes: List<EmoteSheetData>) -> Unit = {},
     val onReplyClick: (rootMessageId: String, replyName: UserName) -> Unit = { _, _ -> },
+    val onMessageTap: ((MessageTapContext) -> Unit)? = null,
     val onWhisperReply: ((userName: UserName) -> Unit)? = null,
     val onAutomodAllow: (heldMessageId: String, channel: UserName) -> Unit = { _, _ -> },
     val onAutomodDeny: (heldMessageId: String, channel: UserName) -> Unit = { _, _ -> },
@@ -868,6 +869,9 @@ private fun ChatMessageItem(
                 onMessageLongClick = callbacks.onMessageLongClick,
                 onEmoteClick = callbacks.onEmoteClick,
                 onReplyClick = callbacks.onReplyClick,
+                onTap = callbacks.onMessageTap?.let { onTap ->
+                    { onTap(message.toMessageTapContext()) }
+                },
             )
         }
 
@@ -899,6 +903,9 @@ private fun ChatMessageItem(
                 },
                 onEmoteClick = callbacks.onEmoteClick,
                 onWhisperReply = callbacks.onWhisperReply,
+                onTap = callbacks.onMessageTap?.let { onTap ->
+                    { onTap(message.toMessageTapContext()) }
+                },
             )
         }
     }

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/MessageTapHandler.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/MessageTapHandler.kt
@@ -1,0 +1,82 @@
+package com.flxrs.dankchat.ui.chat
+
+import androidx.compose.runtime.Immutable
+import com.flxrs.dankchat.data.DisplayName
+import com.flxrs.dankchat.data.UserId
+import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.preferences.chat.MessageTapAction
+import kotlinx.collections.immutable.ImmutableList
+
+@Immutable
+data class MessageTapContext(
+    val messageId: String,
+    val channel: UserName?,
+    val userId: UserId?,
+    val userName: UserName,
+    val displayName: DisplayName,
+    val badges: ImmutableList<BadgeUi>,
+    val message: String,
+    val fullMessage: String,
+    val isWhisper: Boolean,
+)
+
+internal fun ChatMessageUiState.PrivMessageUi.toMessageTapContext() = MessageTapContext(
+    messageId = id,
+    channel = channel,
+    userId = userId,
+    userName = userName,
+    displayName = displayName,
+    badges = badges,
+    message = message,
+    fullMessage = fullMessage,
+    isWhisper = false,
+)
+
+internal fun ChatMessageUiState.WhisperMessageUi.toMessageTapContext() = MessageTapContext(
+    messageId = id,
+    channel = null,
+    userId = replyTargetUserId,
+    userName = replyTargetName,
+    displayName = replyTargetDisplayName,
+    badges = replyTargetBadges,
+    message = message,
+    fullMessage = fullMessage,
+    isWhisper = true,
+)
+
+internal data class MessageTapOperations(
+    val reply: (MessageTapContext) -> Unit,
+    val mention: (MessageTapContext) -> Unit,
+    val whisper: (MessageTapContext) -> Unit,
+    val openUserCard: (MessageTapContext) -> Unit,
+    val openMessageOptions: (MessageTapContext) -> Unit,
+    val copyMessage: (String) -> Unit,
+    val copyFullMessage: (String) -> Unit,
+)
+
+internal fun messageTapHandler(
+    action: MessageTapAction,
+    isLoggedIn: Boolean,
+    operations: MessageTapOperations,
+): ((MessageTapContext) -> Unit)? {
+    val requiresLogin =
+        action == MessageTapAction.Reply ||
+            action == MessageTapAction.Mention ||
+            action == MessageTapAction.Whisper
+    if (action == MessageTapAction.DoNothing || (requiresLogin && !isLoggedIn)) {
+        return null
+    }
+
+    return { message ->
+        when (action) {
+            MessageTapAction.DoNothing -> Unit
+            MessageTapAction.Reply -> operations.reply(message)
+            MessageTapAction.Mention -> operations.mention(message)
+            MessageTapAction.Whisper -> operations.whisper(message)
+            MessageTapAction.OpenUserCard -> operations.openUserCard(message)
+            MessageTapAction.OpenMessageOptions -> operations.openMessageOptions(message)
+            MessageTapAction.CopyMessage -> operations.copyMessage(message.message)
+            MessageTapAction.CopyFullMessage -> operations.copyFullMessage(message.fullMessage)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/PinnedMessageBanner.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/PinnedMessageBanner.kt
@@ -85,6 +85,9 @@ fun PinnedMessageBanner(
                 onMessageLongClick = callbacks.onMessageLongClick,
                 onEmoteClick = callbacks.onEmoteClick,
                 onReplyClick = callbacks.onReplyClick,
+                onTap = callbacks.onMessageTap?.let { onTap ->
+                    { onTap(state.message.toMessageTapContext()) }
+                },
                 animateGifs = animateGifs,
             )
         }

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/mention/MentionComposable.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/mention/MentionComposable.kt
@@ -9,14 +9,25 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flxrs.dankchat.data.DisplayName
 import com.flxrs.dankchat.data.UserId
 import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.preferences.DankChatPreferenceStore
+import com.flxrs.dankchat.preferences.chat.ChatSettingsDataStore
+import com.flxrs.dankchat.preferences.chat.MessageTapAction
+import com.flxrs.dankchat.ui.chat.BadgeUi
 import com.flxrs.dankchat.ui.chat.ChatScreen
 import com.flxrs.dankchat.ui.chat.ChatScreenCallbacks
+import com.flxrs.dankchat.ui.chat.MessageTapContext
+import com.flxrs.dankchat.ui.chat.MessageTapOperations
 import com.flxrs.dankchat.ui.chat.emote.EmoteInfoViewModel
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsParams
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsViewModel
+import com.flxrs.dankchat.ui.chat.message.rememberMessageCopyActions
+import com.flxrs.dankchat.ui.chat.messageTapHandler
 import com.flxrs.dankchat.ui.chat.user.UserPopupStateParams
 import com.flxrs.dankchat.ui.chat.user.UserPopupViewModel
+import com.flxrs.dankchat.ui.main.input.ChatInputViewModel
+import com.flxrs.dankchat.ui.main.sheet.SheetNavigationViewModel
 import kotlinx.collections.immutable.persistentListOf
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -33,7 +44,74 @@ fun MentionComposable(
     val emoteInfoViewModel: EmoteInfoViewModel = koinViewModel()
     val userPopupViewModel: UserPopupViewModel = koinViewModel()
     val messageOptionsViewModel: MessageOptionsViewModel = koinViewModel()
+    val chatInputViewModel: ChatInputViewModel = koinViewModel()
+    val sheetNavigationViewModel: SheetNavigationViewModel = koinViewModel()
+    val chatSettingsDataStore: ChatSettingsDataStore = koinInject()
+    val preferenceStore: DankChatPreferenceStore = koinInject()
     val displaySettings by mentionViewModel.chatDisplaySettings.collectAsStateWithLifecycle()
+    val messageTapAction by
+        chatSettingsDataStore.messageTapAction.collectAsStateWithLifecycle(
+            initialValue = chatSettingsDataStore.current().messageTapAction,
+        )
+    val messageCopyActions = rememberMessageCopyActions()
+    val openUserCard: (String?, String, String, String?, List<BadgeUi>) -> Unit = { userId, userName, displayName, channel, badges ->
+        userPopupViewModel.show(
+            UserPopupStateParams(
+                targetUserId = userId?.let { UserId(it) },
+                targetUserName = UserName(userName),
+                targetDisplayName = DisplayName(displayName),
+                channel = channel?.let { UserName(it) },
+                badges = badges.map { it.badge },
+            ),
+        )
+    }
+    val openMessageOptions: (String, String?, String) -> Unit = { messageId, channel, fullMessage ->
+        messageOptionsViewModel.show(
+            MessageOptionsParams(
+                messageId = messageId,
+                channel = channel?.let { UserName(it) },
+                fullMessage = fullMessage,
+                canModerate = false,
+                canReply = false,
+                canCopy = true,
+                canJump = true,
+            ),
+        )
+    }
+    val whisperUser: (MessageTapContext) -> Unit = { message ->
+        sheetNavigationViewModel.openWhispers()
+        chatInputViewModel.setWhisperTarget(message.userName)
+    }
+    val onMessageTap =
+        messageTapHandler(
+            action = messageTapAction,
+            isLoggedIn = preferenceStore.isLoggedIn,
+            operations =
+                MessageTapOperations(
+                    reply = { message ->
+                        if (message.isWhisper) {
+                            onWhisperReply?.invoke(message.userName)
+                        }
+                    },
+                    mention = { message -> chatInputViewModel.mentionUser(message.userName, message.displayName) },
+                    whisper = whisperUser,
+                    openUserCard = { message ->
+                        openUserCard(
+                            message.userId?.value,
+                            message.userName.value,
+                            message.displayName.value,
+                            message.channel?.value,
+                            message.badges,
+                        )
+                    },
+                    openMessageOptions = { message -> openMessageOptions(message.messageId, message.channel?.value, message.fullMessage) },
+                    copyMessage = messageCopyActions.copyMessage,
+                    copyFullMessage = messageCopyActions.copyFullMessage,
+                ),
+        )
+    val canTapMentions =
+        messageTapAction != MessageTapAction.Reply &&
+            messageTapAction != MessageTapAction.Mention
     val messages by when {
         isWhisperTab -> mentionViewModel.whispersUiStates.collectAsStateWithLifecycle(initialValue = persistentListOf())
         else -> mentionViewModel.mentionsUiStates.collectAsStateWithLifecycle(initialValue = persistentListOf())
@@ -45,31 +123,12 @@ fun MentionComposable(
         callbacks =
             ChatScreenCallbacks(
                 onUserClick = { userId, userName, displayName, channel, badges, _ ->
-                    userPopupViewModel.show(
-                        UserPopupStateParams(
-                            targetUserId = userId?.let { UserId(it) },
-                            targetUserName = UserName(userName),
-                            targetDisplayName = DisplayName(displayName),
-                            channel = channel?.let { UserName(it) },
-                            badges = badges.map { it.badge },
-                        ),
-                    )
+                    openUserCard(userId, userName, displayName, channel, badges)
                 },
-                onMessageLongClick = { messageId, channel, fullMessage ->
-                    messageOptionsViewModel.show(
-                        MessageOptionsParams(
-                            messageId = messageId,
-                            channel = channel?.let { UserName(it) },
-                            fullMessage = fullMessage,
-                            canModerate = false,
-                            canReply = false,
-                            canCopy = true,
-                            canJump = true,
-                        ),
-                    )
-                },
+                onMessageLongClick = openMessageOptions,
                 onEmoteClick = { emoteInfoViewModel.show(it) },
                 onWhisperReply = if (isWhisperTab) onWhisperReply else null,
+                onMessageTap = if (isWhisperTab || canTapMentions) onMessageTap else null,
             ),
         animateGifs = displaySettings.animateGifs,
         showChannelPrefix = !isWhisperTab,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/message/MessageCopyActions.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/message/MessageCopyActions.kt
@@ -1,0 +1,43 @@
+package com.flxrs.dankchat.ui.chat.message
+
+import android.content.ClipData
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import com.flxrs.dankchat.ui.main.MainEvent
+import com.flxrs.dankchat.ui.main.MainEventBus
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+@Immutable
+data class MessageCopyActions(
+    val copyMessage: (String) -> Unit,
+    val copyFullMessage: (String) -> Unit,
+)
+
+@Composable
+fun rememberMessageCopyActions(): MessageCopyActions {
+    val clipboard = LocalClipboard.current
+    val mainEventBus: MainEventBus = koinInject()
+    val scope = rememberCoroutineScope()
+
+    return remember(clipboard, mainEventBus, scope) {
+        fun copy(
+            label: String,
+            text: String,
+        ) {
+            scope.launch {
+                clipboard.setClipEntry(ClipEntry(ClipData.newPlainText(label, text)))
+                mainEventBus.emitEvent(MainEvent.MessageCopied(text))
+            }
+        }
+
+        MessageCopyActions(
+            copyMessage = { copy("message", it) },
+            copyFullMessage = { copy("full message", it) },
+        )
+    }
+}

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/PrivMessage.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/PrivMessage.kt
@@ -2,6 +2,7 @@ package com.flxrs.dankchat.ui.chat.messages
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -71,6 +72,7 @@ fun PrivMessageComposable(
     onEmoteClick: (emotes: List<EmoteSheetData>) -> Unit,
     onReplyClick: (rootMessageId: String, replyName: UserName) -> Unit,
     modifier: Modifier = Modifier,
+    onTap: (() -> Unit)? = null,
     highlightShape: Shape = RectangleShape,
     showChannelPrefix: Boolean = false,
     animateGifs: Boolean = true,
@@ -85,7 +87,17 @@ fun PrivMessageComposable(
                 .wrapContentHeight()
                 .alpha(message.textAlpha)
                 .background(backgroundColor, highlightShape)
-                .indication(interactionSource, ripple())
+                .then(
+                    if (onTap != null) {
+                        Modifier.clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                            onClick = onTap,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ).indication(interactionSource, ripple())
                 .padding(horizontal = 6.dp, vertical = 3.dp),
     ) {
         // Highlight type header (First Time Chat, Elevated Chat)
@@ -192,6 +204,7 @@ fun PrivMessageComposable(
             onUserClick = onUserClick,
             onMessageLongClick = onMessageLongClick,
             onEmoteClick = onEmoteClick,
+            onTap = onTap,
         )
     }
 }
@@ -207,6 +220,7 @@ private fun PrivMessageText(
     onUserClick: (userId: String?, userName: String, displayName: String, channel: String?, badges: List<BadgeUi>, isLongPress: Boolean) -> Unit,
     onMessageLongClick: (messageId: String, channel: String?, fullMessage: String) -> Unit,
     onEmoteClick: (emotes: List<EmoteSheetData>) -> Unit,
+    onTap: (() -> Unit)?,
 ) {
     val context = LocalPlatformContext.current
     val defaultTextColor = rememberAdaptiveTextColor(backgroundColor)
@@ -332,16 +346,20 @@ private fun PrivMessageText(
         animateGifs = animateGifs,
         interactionSource = interactionSource,
         onEmoteClick = onEmoteClick,
+        onBackgroundClick = {
+            onTap?.invoke()
+        },
         onTextClick = { offset ->
             val user = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()
             val url = annotatedString.getStringAnnotations("URL", offset, offset).firstOrNull()
-
             when {
                 user != null -> parseUserAnnotation(user.item)?.let {
                     onUserClick(it.userId, it.userName, it.displayName, it.channel.orEmpty(), message.badges, false)
                 }
 
                 url != null -> launchCustomTab(context, url.item)
+
+                else -> onTap?.invoke()
             }
         },
         onTextLongClick = { offset ->

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/WhisperAndRedemption.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/WhisperAndRedemption.kt
@@ -1,6 +1,7 @@
 package com.flxrs.dankchat.ui.chat.messages
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -69,6 +70,7 @@ fun WhisperMessageComposable(
     modifier: Modifier = Modifier,
     animateGifs: Boolean = true,
     onWhisperReply: ((userName: UserName) -> Unit)? = null,
+    onTap: (() -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val backgroundColor = rememberBackgroundColor(message.lightBackgroundColor, message.darkBackgroundColor)
@@ -81,7 +83,17 @@ fun WhisperMessageComposable(
                 .wrapContentHeight()
                 .alpha(message.textAlpha)
                 .background(backgroundColor)
-                .indication(interactionSource, ripple())
+                .then(
+                    if (onTap != null) {
+                        Modifier.clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                            onClick = onTap,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ).indication(interactionSource, ripple())
                 .padding(horizontal = 6.dp, vertical = 3.dp),
     ) {
         Box(modifier = Modifier.weight(1f)) {
@@ -93,6 +105,7 @@ fun WhisperMessageComposable(
                 onUserClick = onUserClick,
                 onMessageLongClick = onMessageLongClick,
                 onEmoteClick = onEmoteClick,
+                onTap = onTap,
             )
         }
         if (onWhisperReply != null) {
@@ -120,6 +133,7 @@ private fun WhisperMessageText(
     onUserClick: (userId: String?, userName: String, displayName: String, badges: List<BadgeUi>, isLongPress: Boolean) -> Unit,
     onMessageLongClick: (messageId: String, fullMessage: String) -> Unit,
     onEmoteClick: (emotes: List<EmoteSheetData>) -> Unit,
+    onTap: (() -> Unit)?,
 ) {
     val context = LocalPlatformContext.current
     val defaultTextColor = rememberAdaptiveTextColor(backgroundColor)
@@ -214,16 +228,18 @@ private fun WhisperMessageText(
         fontSize = fontSize,
         animateGifs = animateGifs,
         onEmoteClick = onEmoteClick,
+        onBackgroundClick = { onTap?.invoke() },
         onTextClick = { offset ->
             val user = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()
             val url = annotatedString.getStringAnnotations("URL", offset, offset).firstOrNull()
-
             when {
                 user != null -> parseUserAnnotation(user.item)?.let {
                     onUserClick(it.userId, it.userName, it.displayName, message.badges, false)
                 }
 
                 url != null -> launchCustomTab(context, url.item)
+
+                else -> onTap?.invoke()
             }
         },
         onTextLongClick = { offset ->

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/MessageTextRenderer.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/MessageTextRenderer.kt
@@ -50,6 +50,7 @@ fun MessageTextWithInlineContent(
     onTextClick: (Int) -> Unit,
     onEmoteClick: (List<EmoteSheetData>) -> Unit,
     modifier: Modifier = Modifier,
+    onBackgroundClick: (() -> Unit)? = null,
     onTextLongClick: ((Int) -> Unit)? = null,
     interactionSource: MutableInteractionSource? = null,
 ) {
@@ -137,6 +138,7 @@ fun MessageTextWithInlineContent(
         modifier = modifier.fillMaxWidth(),
         interactionSource = interactionSource,
         onTextClick = onTextClick,
+        onBackgroundClick = onBackgroundClick,
         onTextLongClick = onTextLongClick,
     )
 }

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/TextWithMeasuredInlineContent.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/TextWithMeasuredInlineContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -37,6 +38,7 @@ fun TextWithMeasuredInlineContent(
     style: TextStyle = TextStyle.Default,
     knownDimensions: ImmutableMap<String, EmoteDimensions> = persistentMapOf(),
     onTextClick: ((Int) -> Unit)? = null,
+    onBackgroundClick: (() -> Unit)? = null,
     onTextLongClick: ((Int) -> Unit)? = null,
     interactionSource: MutableInteractionSource? = null,
 ) {
@@ -50,6 +52,7 @@ fun TextWithMeasuredInlineContent(
         inlineContent = inlineContent,
         modifier = modifier,
         onTextClick = onTextClick,
+        onBackgroundClick = onBackgroundClick,
         onTextLongClick = onTextLongClick,
         interactionSource = interactionSource,
     )
@@ -61,12 +64,16 @@ private fun ClickableInlineText(
     style: TextStyle,
     inlineContent: Map<String, InlineTextContent>,
     onTextClick: ((Int) -> Unit)?,
+    onBackgroundClick: (() -> Unit)?,
     onTextLongClick: ((Int) -> Unit)?,
     interactionSource: MutableInteractionSource?,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val textLayoutResultRef = remember { mutableStateOf<TextLayoutResult?>(null) }
+    val currentOnTextClick = rememberUpdatedState(onTextClick)
+    val currentOnBackgroundClick = rememberUpdatedState(onBackgroundClick)
+    val currentOnTextLongClick = rememberUpdatedState(onTextLongClick)
 
     BasicText(
         text = text,
@@ -91,7 +98,9 @@ private fun ClickableInlineText(
                             val lineLeft = layoutResult.getLineLeft(line)
                             val lineRight = layoutResult.getLineRight(line)
                             if (offset.x in lineLeft..lineRight) {
-                                onTextClick?.invoke(layoutResult.getOffsetForPosition(offset))
+                                currentOnTextClick.value?.invoke(layoutResult.getOffsetForPosition(offset))
+                            } else {
+                                currentOnBackgroundClick.value?.invoke()
                             }
                         }
                     },
@@ -102,12 +111,12 @@ private fun ClickableInlineText(
                             val lineLeft = layoutResult.getLineLeft(line)
                             val lineRight = layoutResult.getLineRight(line)
                             if (offset.x in lineLeft..lineRight) {
-                                onTextLongClick?.invoke(layoutResult.getOffsetForPosition(offset))
+                                currentOnTextLongClick.value?.invoke(layoutResult.getOffsetForPosition(offset))
                             } else {
-                                onTextLongClick?.invoke(-1)
+                                currentOnTextLongClick.value?.invoke(-1)
                             }
                         } else {
-                            onTextLongClick?.invoke(-1)
+                            currentOnTextLongClick.value?.invoke(-1)
                         }
                     },
                 )

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/replies/RepliesComposable.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/replies/RepliesComposable.kt
@@ -10,16 +10,23 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flxrs.dankchat.data.DisplayName
 import com.flxrs.dankchat.data.UserId
 import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.preferences.DankChatPreferenceStore
 import com.flxrs.dankchat.preferences.chat.ChatSettingsDataStore
 import com.flxrs.dankchat.preferences.chat.UserLongClickBehavior
+import com.flxrs.dankchat.ui.chat.BadgeUi
 import com.flxrs.dankchat.ui.chat.ChatScreen
 import com.flxrs.dankchat.ui.chat.ChatScreenCallbacks
+import com.flxrs.dankchat.ui.chat.MessageTapContext
+import com.flxrs.dankchat.ui.chat.MessageTapOperations
 import com.flxrs.dankchat.ui.chat.emote.EmoteInfoViewModel
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsParams
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsViewModel
+import com.flxrs.dankchat.ui.chat.message.rememberMessageCopyActions
+import com.flxrs.dankchat.ui.chat.messageTapHandler
 import com.flxrs.dankchat.ui.chat.user.UserPopupStateParams
 import com.flxrs.dankchat.ui.chat.user.UserPopupViewModel
 import com.flxrs.dankchat.ui.main.input.ChatInputViewModel
+import com.flxrs.dankchat.ui.main.sheet.SheetNavigationViewModel
 import kotlinx.collections.immutable.persistentListOf
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -38,9 +45,67 @@ fun RepliesComposable(
     val userPopupViewModel: UserPopupViewModel = koinViewModel()
     val messageOptionsViewModel: MessageOptionsViewModel = koinViewModel()
     val chatInputViewModel: ChatInputViewModel = koinViewModel()
+    val sheetNavigationViewModel: SheetNavigationViewModel = koinViewModel()
     val chatSettingsDataStore: ChatSettingsDataStore = koinInject()
+    val preferenceStore: DankChatPreferenceStore = koinInject()
     val displaySettings by repliesViewModel.chatDisplaySettings.collectAsStateWithLifecycle()
     val userLongClickBehavior by chatSettingsDataStore.userLongClickBehavior.collectAsStateWithLifecycle(initialValue = UserLongClickBehavior.MentionsUser)
+    val messageTapAction by
+        chatSettingsDataStore.messageTapAction.collectAsStateWithLifecycle(
+            initialValue = chatSettingsDataStore.current().messageTapAction,
+        )
+    val messageCopyActions = rememberMessageCopyActions()
+    val openUserCard: (String?, String, String, String?, List<BadgeUi>) -> Unit = { userId, userName, displayName, channel, badges ->
+        userPopupViewModel.show(
+            UserPopupStateParams(
+                targetUserId = userId?.let { UserId(it) },
+                targetUserName = UserName(userName),
+                targetDisplayName = DisplayName(displayName),
+                channel = channel?.let { UserName(it) },
+                badges = badges.map { it.badge },
+            ),
+        )
+    }
+    val openMessageOptions: (String, String?, String) -> Unit = { messageId, channel, fullMessage ->
+        messageOptionsViewModel.show(
+            MessageOptionsParams(
+                messageId = messageId,
+                channel = channel?.let { UserName(it) },
+                fullMessage = fullMessage,
+                canModerate = false,
+                canReply = false,
+                canCopy = true,
+                canJump = true,
+            ),
+        )
+    }
+    val whisperUser: (MessageTapContext) -> Unit = { message ->
+        sheetNavigationViewModel.openWhispers()
+        chatInputViewModel.setWhisperTarget(message.userName)
+    }
+    val onMessageTap =
+        messageTapHandler(
+            action = messageTapAction,
+            isLoggedIn = preferenceStore.isLoggedIn,
+            operations =
+                MessageTapOperations(
+                    reply = { message -> chatInputViewModel.setReplying(true, message.messageId, message.userName, message.message) },
+                    mention = { message -> chatInputViewModel.mentionUser(message.userName, message.displayName) },
+                    whisper = whisperUser,
+                    openUserCard = { message ->
+                        openUserCard(
+                            message.userId?.value,
+                            message.userName.value,
+                            message.displayName.value,
+                            message.channel?.value,
+                            message.badges,
+                        )
+                    },
+                    openMessageOptions = { message -> openMessageOptions(message.messageId, message.channel?.value, message.fullMessage) },
+                    copyMessage = messageCopyActions.copyMessage,
+                    copyFullMessage = messageCopyActions.copyFullMessage,
+                ),
+        )
     val uiState by repliesViewModel.uiState.collectAsStateWithLifecycle(initialValue = RepliesUiState.Found(persistentListOf()))
 
     when (uiState) {
@@ -57,33 +122,14 @@ fun RepliesComposable(
                                     UserLongClickBehavior.OpensPopup -> isLongPress
                                 }
                             if (shouldOpenPopup) {
-                                userPopupViewModel.show(
-                                    UserPopupStateParams(
-                                        targetUserId = userId?.let { UserId(it) },
-                                        targetUserName = UserName(userName),
-                                        targetDisplayName = DisplayName(displayName),
-                                        channel = channel?.let { UserName(it) },
-                                        badges = badges.map { it.badge },
-                                    ),
-                                )
+                                openUserCard(userId, userName, displayName, channel, badges)
                             } else {
                                 chatInputViewModel.mentionUser(UserName(userName), DisplayName(displayName))
                             }
                         },
-                        onMessageLongClick = { messageId, channel, fullMessage ->
-                            messageOptionsViewModel.show(
-                                MessageOptionsParams(
-                                    messageId = messageId,
-                                    channel = channel?.let { UserName(it) },
-                                    fullMessage = fullMessage,
-                                    canModerate = false,
-                                    canReply = false,
-                                    canCopy = true,
-                                    canJump = true,
-                                ),
-                            )
-                        },
+                        onMessageLongClick = openMessageOptions,
                         onEmoteClick = { emoteInfoViewModel.show(it) },
+                        onMessageTap = onMessageTap,
                     ),
                 animateGifs = displaySettings.animateGifs,
                 modifier = modifier,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/MessageOptionsSheetContainer.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/MessageOptionsSheetContainer.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flxrs.dankchat.data.UserName
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsState
 import com.flxrs.dankchat.ui.chat.message.MessageOptionsViewModel
+import com.flxrs.dankchat.ui.chat.message.rememberMessageCopyActions
 import com.flxrs.dankchat.ui.main.MainEvent
 import com.flxrs.dankchat.ui.main.MainEventBus
 import com.flxrs.dankchat.ui.main.input.ChatInputViewModel
@@ -31,6 +32,7 @@ fun MessageOptionsSheetContainer(onJumpToMessage: (messageId: String, channel: U
     val params = currentState.params
     val found = currentState.optionsState as? MessageOptionsState.Found ?: return
     val clipboardManager = LocalClipboard.current
+    val messageCopyActions = rememberMessageCopyActions()
     val scope = rememberCoroutineScope()
 
     when (found) {
@@ -58,16 +60,10 @@ fun MessageOptionsSheetContainer(onJumpToMessage: (messageId: String, channel: U
                     sheetNavigationViewModel.openReplies(found.rootThreadId, found.replyName)
                 },
                 onCopy = {
-                    scope.launch {
-                        clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText("message", found.originalMessage)))
-                        mainEventBus.emitEvent(MainEvent.MessageCopied(found.originalMessage))
-                    }
+                    messageCopyActions.copyMessage(found.originalMessage)
                 },
                 onCopyFullMessage = {
-                    scope.launch {
-                        clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText("full message", params.fullMessage)))
-                        mainEventBus.emitEvent(MainEvent.MessageCopied(params.fullMessage))
-                    }
+                    messageCopyActions.copyFullMessage(params.fullMessage)
                 },
                 onCopyMessageId = {
                     scope.launch {
@@ -95,10 +91,7 @@ fun MessageOptionsSheetContainer(onJumpToMessage: (messageId: String, channel: U
                 canModerate = found.canModerate,
                 startWithBan = params.startWithBan,
                 onCopy = {
-                    scope.launch {
-                        clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText("message", found.originalMessage)))
-                        mainEventBus.emitEvent(MainEvent.MessageCopied(found.originalMessage))
-                    }
+                    messageCopyActions.copyMessage(found.originalMessage)
                 },
                 onBan = messageOptionsViewModel::banUser,
                 onUnban = messageOptionsViewModel::unbanUser,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputLayout.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputLayout.kt
@@ -227,6 +227,12 @@ fun ChatInputLayout(
     val view = LocalView.current
     val inputMethodManager = remember(view) { view.context.getSystemService(InputMethodManager::class.java) }
     val keyboardController = LocalSoftwareKeyboardController.current
+    LaunchedEffect(overlay) {
+        if (overlay is InputOverlay.Reply || overlay is InputOverlay.Whisper) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
     var visibleActions by remember { mutableStateOf(effectiveActions) }
     val quickActionsExpanded = overflowExpanded || tourState.forceOverflowOpen
     var showConfigSheet by remember { mutableStateOf(false) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,6 +462,15 @@
     <string name="preference_general_header">General</string>
     <string name="preference_suggestions_header">Suggestions</string>
     <string name="preference_messages_header">Messages</string>
+    <string name="preference_message_tap_action_title">Message tap action</string>
+    <string name="preference_message_tap_action_do_nothing">Do nothing</string>
+    <string name="preference_message_tap_action_reply">Reply to message</string>
+    <string name="preference_message_tap_action_mention">Mention user</string>
+    <string name="preference_message_tap_action_whisper">Whisper user</string>
+    <string name="preference_message_tap_action_open_user_card">Open user card</string>
+    <string name="preference_message_tap_action_open_message_options">Open message options</string>
+    <string name="preference_message_tap_action_copy_message">Copy message</string>
+    <string name="preference_message_tap_action_copy_full_message">Copy full message</string>
     <string name="preference_users_header">Users</string>
     <string name="preference_emotes_badges_header">Emotes &amp; Badges</string>
     <string name="preference_suggestion_mode_title">Suggestion mode</string>

--- a/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapperTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapperTest.kt
@@ -1,0 +1,40 @@
+package com.flxrs.dankchat.ui.chat
+
+import com.flxrs.dankchat.data.toDisplayName
+import com.flxrs.dankchat.data.toUserId
+import com.flxrs.dankchat.data.toUserName
+import com.flxrs.dankchat.data.twitch.message.WhisperMessage
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class ChatMessageMapperTest {
+    @Test
+    fun `sent whisper actions target recipient`() {
+        val target = whisper().resolveWhisperReplyTarget("sender".toUserName())
+
+        assertEquals("recipient".toUserName(), target.userName)
+        assertEquals("recipient-id".toUserId(), target.userId)
+        assertEquals("Recipient".toDisplayName(), target.displayName)
+    }
+
+    @Test
+    fun `received whisper actions target sender`() {
+        val target = whisper().resolveWhisperReplyTarget("recipient".toUserName())
+
+        assertEquals("sender".toUserName(), target.userName)
+        assertEquals("sender-id".toUserId(), target.userId)
+        assertEquals("Sender".toDisplayName(), target.displayName)
+    }
+
+    private fun whisper() = WhisperMessage(
+        userId = "sender-id".toUserId(),
+        name = "sender".toUserName(),
+        displayName = "Sender".toDisplayName(),
+        recipientId = "recipient-id".toUserId(),
+        recipientName = "recipient".toUserName(),
+        recipientDisplayName = "Recipient".toDisplayName(),
+        message = "message",
+        rawEmotes = "",
+        rawBadges = "",
+    )
+}

--- a/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/MessageTapHandlerTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/MessageTapHandlerTest.kt
@@ -1,0 +1,66 @@
+package com.flxrs.dankchat.ui.chat
+
+import com.flxrs.dankchat.data.toDisplayName
+import com.flxrs.dankchat.data.toUserName
+import com.flxrs.dankchat.preferences.chat.MessageTapAction
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+internal class MessageTapHandlerTest {
+    @Test
+    fun `each configured action invokes its matching operation`() {
+        var invoked: MessageTapAction? = null
+        val operations =
+            MessageTapOperations(
+                reply = { invoked = MessageTapAction.Reply },
+                mention = { invoked = MessageTapAction.Mention },
+                whisper = { invoked = MessageTapAction.Whisper },
+                openUserCard = { invoked = MessageTapAction.OpenUserCard },
+                openMessageOptions = { invoked = MessageTapAction.OpenMessageOptions },
+                copyMessage = { invoked = MessageTapAction.CopyMessage },
+                copyFullMessage = { invoked = MessageTapAction.CopyFullMessage },
+            )
+
+        MessageTapAction.entries.drop(1).forEach { action ->
+            invoked = null
+            messageTapHandler(action, isLoggedIn = true, operations)?.invoke(message)
+            assertEquals(action, invoked)
+        }
+    }
+
+    @Test
+    fun `do nothing and unavailable account actions have no handler`() {
+        assertNull(messageTapHandler(MessageTapAction.DoNothing, isLoggedIn = true, operations))
+        assertNull(messageTapHandler(MessageTapAction.Reply, isLoggedIn = false, operations))
+        assertNull(messageTapHandler(MessageTapAction.Mention, isLoggedIn = false, operations))
+        assertNull(messageTapHandler(MessageTapAction.Whisper, isLoggedIn = false, operations))
+        assertNotNull(messageTapHandler(MessageTapAction.CopyMessage, isLoggedIn = false, operations))
+    }
+
+    private val message =
+        MessageTapContext(
+            messageId = "message-id",
+            channel = "channel".toUserName(),
+            userId = null,
+            userName = "user".toUserName(),
+            displayName = "User".toDisplayName(),
+            badges = persistentListOf(),
+            message = "message",
+            fullMessage = "user: message",
+            isWhisper = false,
+        )
+
+    private val operations =
+        MessageTapOperations(
+            reply = {},
+            mention = {},
+            whisper = {},
+            openUserCard = {},
+            openMessageOptions = {},
+            copyMessage = {},
+            copyFullMessage = {},
+        )
+}


### PR DESCRIPTION
Adds the option to perform an action when tapping a message.

Available actions:
- Do nothing (default)
- Reply to message
- Mention user
- Whisper user
- Open user card
- Open message options
- Copy message
- Copy full message

Tapping usernames, links, emotes, etc. still works as before.

<details><summary>Screenshots</summary>
<img width="300" alt="Screenshot_1" src="https://github.com/user-attachments/assets/d7af4728-311d-4743-bd62-7f281cf90edc" />

<img width="300"  alt="Screenshot_2" src="https://github.com/user-attachments/assets/5f891c95-49d6-4ab4-955b-22f9f6637777" />
</details>