### PR TITLE
feat: dismiss keyboard by swiping down on input

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/MainScreen.kt
@@ -201,6 +201,7 @@ fun MainScreen(
 
     val inputState by chatInputViewModel.uiState(sheetNavigationViewModel.fullScreenSheetState, mentionViewModel.currentTab).collectAsStateWithLifecycle()
     val isKeyboardVisible = isImeVisible || isImeOpening
+    val isKeyboardVisibleState = rememberUpdatedState(isKeyboardVisible)
     var backProgress by remember { mutableFloatStateOf(0f) }
 
     // Stream state
@@ -391,7 +392,7 @@ fun MainScreen(
     var helperTextHeightPx by remember { mutableIntStateOf(0) }
     var inputOverflowExpanded by remember { mutableStateOf(false) }
     var recentMessagesExpanded by remember { mutableStateOf(false) }
-    var isInputMultiline by remember { mutableStateOf(false) }
+    var isInputScrollable by remember { mutableStateOf(false) }
     var toolbarBottomPx by remember { mutableIntStateOf(0) }
     if (!showInput) inputHeightPx = 0
     if (showInput || inputState.helperText.isEmpty) helperTextHeightPx = 0
@@ -540,7 +541,7 @@ fun MainScreen(
                                     null
                                 },
                             onRepeatedSendChange = chatInputViewModel::setRepeatedSend,
-                            onInputMultilineChanged = { isInputMultiline = it },
+                            onInputScrollableChanged = { isInputScrollable = it },
                         ),
                     isUploading = dialogState.isUploading,
                     isLoading = tabState.loading,
@@ -900,6 +901,13 @@ fun MainScreen(
                 streamViewModel.closeStream()
             }
             val onAudioOnly = { streamViewModel.toggleAudioOnly() }
+            val onInputSwipeDown: () -> Unit = {
+                if (isKeyboardVisibleState.value) {
+                    keyboardController?.hide()
+                } else {
+                    mainScreenViewModel.hideInput()
+                }
+            }
 
             // The theater chat follows the finger during drags and settles to the nearest edge
             // on release, with the settled position mirrored into the ViewModel. The panel width
@@ -995,7 +1003,7 @@ fun MainScreen(
                     showInput = showInput,
                     isKeyboardVisible = isKeyboardVisible,
                     isSheetOpen = isSheetOpen,
-                    isInputMultiline = isInputMultiline,
+                    isInputScrollable = isInputScrollable,
                     isEmoteMenuOpen = inputState.isEmoteMenuOpen,
                     inputHeightDp = inputHeightDp,
                     helperTextHeightDp = helperTextHeightDp,
@@ -1004,7 +1012,7 @@ fun MainScreen(
                     chatOffsetX = { theaterChatOffset.value },
                     onChatDrag = onTheaterChatDrag,
                     onChatDragEnd = onTheaterChatDragEnd,
-                    onHideInput = { mainScreenViewModel.hideInput() },
+                    onInputSwipeDown = onInputSwipeDown,
                     onOpenReplies = sheetNavigationViewModel::openReplies,
                     onRecover = { mainScreenViewModel.recoverInputAndFullscreen() },
                     streamView = streamView,
@@ -1035,12 +1043,12 @@ fun MainScreen(
                     isSheetOpen = isSheetOpen,
                     isToolbarMenuOpen = isToolbarMenuOpen,
                     showInput = showInput,
-                    isInputMultiline = isInputMultiline,
+                    isInputScrollable = isInputScrollable,
                     inputPopupExpanded = inputOverflowExpanded || recentMessagesExpanded,
                     forceOverflowOpen = featureTourState.forceOverflowOpen,
                     swipeDownThresholdPx = swipeDownThresholdPx,
                     suggestionDropdown = suggestionDropdown,
-                    onHideInput = { mainScreenViewModel.hideInput() },
+                    onInputSwipeDown = onInputSwipeDown,
                     onDismissInputPopup = {
                         inputOverflowExpanded = false
                         recentMessagesExpanded = false
@@ -1051,7 +1059,7 @@ fun MainScreen(
                 NormalStackedLayout(
                     currentStream = currentStream,
                     isAudioOnly = isAudioOnly,
-                    isInputMultiline = isInputMultiline,
+                    isInputScrollable = isInputScrollable,
                     streamView = streamView,
                     hasWebViewBeenAttached = streamViewModel.hasWebViewBeenAttached,
                     streamState = streamState,
@@ -1078,7 +1086,7 @@ fun MainScreen(
                     forceOverflowOpen = featureTourState.forceOverflowOpen,
                     swipeDownThresholdPx = swipeDownThresholdPx,
                     suggestionDropdown = suggestionDropdown,
-                    onHideInput = { mainScreenViewModel.hideInput() },
+                    onInputSwipeDown = onInputSwipeDown,
                     onDismissInputPopup = {
                         inputOverflowExpanded = false
                         recentMessagesExpanded = false

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/NormalStackedLayout.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/NormalStackedLayout.kt
@@ -39,7 +39,7 @@ private const val MIN_VISIBLE_MESSAGE_LINES = 9
 internal fun BoxScope.NormalStackedLayout(
     currentStream: UserName?,
     isAudioOnly: Boolean,
-    isInputMultiline: Boolean,
+    isInputScrollable: Boolean,
     streamView: @Composable (StreamViewConfig, Modifier) -> Unit,
     hasWebViewBeenAttached: Boolean,
     streamState: StreamToolbarState,
@@ -66,7 +66,7 @@ internal fun BoxScope.NormalStackedLayout(
     forceOverflowOpen: Boolean,
     swipeDownThresholdPx: Float,
     suggestionDropdown: @Composable (Modifier) -> Unit,
-    onHideInput: () -> Unit,
+    onInputSwipeDown: () -> Unit,
     onDismissInputPopup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -197,9 +197,9 @@ internal fun BoxScope.NormalStackedLayout(
                     .align(Alignment.BottomCenter)
                     .bottomInsetsPadding(scaffoldBottomInsets)
                     .swipeDownToHide(
-                        enabled = showInput && !isSheetOpen && !isInputMultiline && !isKeyboardVisible && !isEmoteMenuOpen,
+                        enabled = showInput && !isSheetOpen && !isInputScrollable && !isEmoteMenuOpen,
                         thresholdPx = swipeDownThresholdPx,
-                        onHide = onHideInput,
+                        onHide = onInputSwipeDown,
                     ),
         ) {
             bottomBar()

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/TheaterLayout.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/TheaterLayout.kt
@@ -55,7 +55,7 @@ internal fun TheaterLayout(
     showInput: Boolean,
     isKeyboardVisible: Boolean,
     isSheetOpen: Boolean,
-    isInputMultiline: Boolean,
+    isInputScrollable: Boolean,
     isEmoteMenuOpen: Boolean,
     inputHeightDp: Dp,
     helperTextHeightDp: Dp,
@@ -64,7 +64,7 @@ internal fun TheaterLayout(
     chatOffsetX: () -> Float,
     onChatDrag: (Float) -> Unit,
     onChatDragEnd: () -> Unit,
-    onHideInput: () -> Unit,
+    onInputSwipeDown: () -> Unit,
     onOpenReplies: (String, UserName) -> Unit,
     onRecover: () -> Unit,
     streamView: @Composable (StreamViewConfig, Modifier) -> Unit,
@@ -189,9 +189,9 @@ internal fun TheaterLayout(
                                     Modifier
                                         .align(Alignment.BottomCenter)
                                         .swipeDownToHide(
-                                            enabled = showInput && !isSheetOpen && !isInputMultiline && !isKeyboardVisible && !isEmoteMenuOpen,
+                                            enabled = showInput && !isSheetOpen && !isInputScrollable && !isEmoteMenuOpen,
                                             thresholdPx = swipeDownThresholdPx,
-                                            onHide = onHideInput,
+                                            onHide = onInputSwipeDown,
                                         ),
                             ) {
                                 bottomBar()

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/WideSplitLayout.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/WideSplitLayout.kt
@@ -56,12 +56,12 @@ internal fun BoxScope.WideSplitLayout(
     isSheetOpen: Boolean,
     isToolbarMenuOpen: Boolean,
     showInput: Boolean,
-    isInputMultiline: Boolean,
+    isInputScrollable: Boolean,
     inputPopupExpanded: Boolean,
     forceOverflowOpen: Boolean,
     swipeDownThresholdPx: Float,
     suggestionDropdown: @Composable (Modifier) -> Unit,
-    onHideInput: () -> Unit,
+    onInputSwipeDown: () -> Unit,
     onDismissInputPopup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -148,9 +148,9 @@ internal fun BoxScope.WideSplitLayout(
                             .align(Alignment.BottomCenter)
                             .bottomInsetsPadding(scaffoldBottomInsets)
                             .swipeDownToHide(
-                                enabled = showInput && !isSheetOpen && !isInputMultiline && !isKeyboardVisible && !isEmoteMenuOpen,
+                                enabled = showInput && !isSheetOpen && !isInputScrollable && !isEmoteMenuOpen,
                                 thresholdPx = swipeDownThresholdPx,
-                                onHide = onHideInput,
+                                onHide = onInputSwipeDown,
                             ),
                 ) {
                     bottomBar()

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputCallbacks.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputCallbacks.kt
@@ -20,5 +20,5 @@ data class ChatInputCallbacks(
     val onDebugInfoClick: () -> Unit = {},
     val onNewWhisper: (() -> Unit)? = null,
     val onRepeatedSendChange: (Boolean) -> Unit = {},
-    val onInputMultilineChanged: (Boolean) -> Unit = {},
+    val onInputScrollableChanged: (Boolean) -> Unit = {},
 )

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputLayout.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/input/ChatInputLayout.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -35,6 +36,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -270,7 +272,12 @@ fun ChatInputLayout(
 
                 val density = LocalDensity.current
                 var singleLineHeight by remember { mutableIntStateOf(0) }
+                val textFieldScrollState = rememberScrollState()
+                val isInputScrollable = textFieldScrollState.maxValue != Int.MAX_VALUE && textFieldScrollState.maxValue > 0
                 val textFieldEnabled = enabled && !tourState.isTourActive
+                LaunchedEffect(isInputScrollable) {
+                    callbacks.onInputScrollableChanged(isInputScrollable)
+                }
                 val onKeyboardSend: (() -> Unit) -> Unit = {
                     if (canSend) {
                         onSend()
@@ -285,7 +292,6 @@ fun ChatInputLayout(
                             if (textFieldState.text.isEmpty()) {
                                 singleLineHeight = maxOf(singleLineHeight, size.height)
                             }
-                            callbacks.onInputMultilineChanged(singleLineHeight > 0 && size.height > singleLineHeight)
                         }
 
                 val chatTextField: @Composable (Modifier, PaddingValues?) -> Unit = { textFieldModifier, contentPadding ->
@@ -298,6 +304,7 @@ fun ChatInputLayout(
                         focusRequester = focusRequester,
                         textFieldColors = textFieldColors,
                         onKeyboardAction = onKeyboardSend,
+                        scrollState = textFieldScrollState,
                         contentPadding = contentPadding,
                         modifier = textFieldModifier.then(sizeTrackingModifier),
                     )
@@ -1038,6 +1045,7 @@ private fun ChatTextField(
     focusRequester: FocusRequester,
     textFieldColors: TextFieldColors,
     onKeyboardAction: (() -> Unit) -> Unit,
+    scrollState: ScrollState,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues? = null,
 ) {
@@ -1118,6 +1126,7 @@ private fun ChatTextField(
                 imeAction = ImeAction.Send,
             ),
         onKeyboardAction = onKeyboardAction,
+        scrollState = scrollState,
     )
 }
 


### PR DESCRIPTION
Swiping down on the text input while the keyboard is open dismisses the keyboard, but does not hide the input.

Changes the criteria for disabling swipe-down in general; previously the gesture was disabled when the input was multiline, now it is disabled when the input is scrollable. This affects the input hide gesture too.

https://github.com/user-attachments/assets/58aaf72d-ed2b-426d-b196-f291913db300

