### PR TITLE
feat: style @mentions in chat

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettings.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettings.kt
@@ -19,6 +19,8 @@ data class ChatSettings(
     val showUsernames: Boolean = true,
     val userLongClickBehavior: UserLongClickBehavior = UserLongClickBehavior.MentionsUser,
     val colorizeNicknames: Boolean = true,
+    val boldUsernameMentions: Boolean = true,
+    val colorUsernameMentions: Boolean = true,
     val showTimedOutMessages: Boolean = true,
     val showTimestamps: Boolean = true,
     val timestampFormat: String = DEFAULT_TIMESTAMP_FORMAT,

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsScreen.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsScreen.kt
@@ -149,6 +149,8 @@ private fun ChatSettingsScreen(
                 showUsernames = settings.showUsernames,
                 userLongClickBehavior = settings.userLongClickBehavior,
                 colorizeNicknames = settings.colorizeNicknames,
+                boldUsernameMentions = settings.boldUsernameMentions,
+                colorUsernameMentions = settings.colorUsernameMentions,
                 onNavToUserDisplays = onNavToUserDisplays,
                 onInteraction = onInteraction,
             )
@@ -281,6 +283,8 @@ private fun UsersCategory(
     showUsernames: Boolean,
     userLongClickBehavior: UserLongClickBehavior,
     colorizeNicknames: Boolean,
+    boldUsernameMentions: Boolean,
+    colorUsernameMentions: Boolean,
     onNavToUserDisplays: () -> Unit,
     onInteraction: (ChatSettingsInteraction) -> Unit,
 ) {
@@ -306,6 +310,18 @@ private fun UsersCategory(
             summary = stringResource(R.string.preference_colorize_nicknames_summary),
             isChecked = colorizeNicknames,
             onClick = { onInteraction(ChatSettingsInteraction.ColorizeNicknames(it)) },
+        )
+        SwitchPreferenceItem(
+            title = stringResource(R.string.preference_bold_username_mentions_title),
+            summary = stringResource(R.string.preference_bold_username_mentions_summary),
+            isChecked = boldUsernameMentions,
+            onClick = { onInteraction(ChatSettingsInteraction.BoldUsernameMentions(it)) },
+        )
+        SwitchPreferenceItem(
+            title = stringResource(R.string.preference_color_username_mentions_title),
+            summary = stringResource(R.string.preference_color_username_mentions_summary),
+            isChecked = colorUsernameMentions,
+            onClick = { onInteraction(ChatSettingsInteraction.ColorUsernameMentions(it)) },
         )
         PreferenceItem(
             title = stringResource(R.string.custom_user_display_title),

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsState.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsState.kt
@@ -40,6 +40,14 @@ sealed interface ChatSettingsInteraction {
         val value: Boolean,
     ) : ChatSettingsInteraction
 
+    data class BoldUsernameMentions(
+        val value: Boolean,
+    ) : ChatSettingsInteraction
+
+    data class ColorUsernameMentions(
+        val value: Boolean,
+    ) : ChatSettingsInteraction
+
     data class ShowTimedOutMessages(
         val value: Boolean,
     ) : ChatSettingsInteraction
@@ -99,6 +107,8 @@ data class ChatSettingsState(
     val showUsernames: Boolean,
     val userLongClickBehavior: UserLongClickBehavior,
     val colorizeNicknames: Boolean,
+    val boldUsernameMentions: Boolean,
+    val colorUsernameMentions: Boolean,
     val showTimedOutMessages: Boolean,
     val showTimestamps: Boolean,
     val timestampFormat: String,

--- a/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/preferences/chat/ChatSettingsViewModel.kt
@@ -65,6 +65,14 @@ class ChatSettingsViewModel(
                     chatSettingsDataStore.update { it.copy(colorizeNicknames = interaction.value) }
                 }
 
+                is ChatSettingsInteraction.BoldUsernameMentions -> {
+                    chatSettingsDataStore.update { it.copy(boldUsernameMentions = interaction.value) }
+                }
+
+                is ChatSettingsInteraction.ColorUsernameMentions -> {
+                    chatSettingsDataStore.update { it.copy(colorUsernameMentions = interaction.value) }
+                }
+
                 is ChatSettingsInteraction.ShowTimedOutMessages -> {
                     chatSettingsDataStore.update { it.copy(showTimedOutMessages = interaction.value) }
                 }
@@ -132,6 +140,8 @@ private fun ChatSettings.toState() = ChatSettingsState(
     showUsernames = showUsernames,
     userLongClickBehavior = userLongClickBehavior,
     colorizeNicknames = colorizeNicknames,
+    boldUsernameMentions = boldUsernameMentions,
+    colorUsernameMentions = colorUsernameMentions,
     showTimedOutMessages = showTimedOutMessages,
     showTimestamps = showTimestamps,
     timestampFormat = timestampFormat,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapper.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageMapper.kt
@@ -7,6 +7,7 @@ import com.flxrs.dankchat.data.UserName
 import com.flxrs.dankchat.data.chat.ChatImportance
 import com.flxrs.dankchat.data.chat.ChatItem
 import com.flxrs.dankchat.data.repo.chat.UsersRepository
+import com.flxrs.dankchat.data.toDisplayName
 import com.flxrs.dankchat.data.toUserId
 import com.flxrs.dankchat.data.toUserName
 import com.flxrs.dankchat.data.twitch.emote.ChatMessageEmoteType
@@ -655,6 +656,24 @@ class ChatMessageMapper(
             }
 
         val rawNameColor = resolveNameColor(userDisplay?.color, color, userId, chatSettings)
+        val usernameMentions =
+            findUsernameMentions(message)
+                .map { mention ->
+                    val userName = mention.userName.lowercase()
+                    UsernameMentionUi(
+                        start = mention.start,
+                        end = mention.end,
+                        userName = userName,
+                        displayName = usersRepository.findDisplayName(channel, userName) ?: mention.userName.toDisplayName(),
+                        rawColor =
+                            if (chatSettings.colorUsernameMentions) {
+                                usersRepository.getCachedUserColor(userName)
+                            } else {
+                                null
+                            },
+                        isBold = chatSettings.boldUsernameMentions,
+                    )
+                }.toImmutableList()
 
         return ChatMessageUiState.PrivMessageUi(
             id = id,
@@ -674,6 +693,7 @@ class ChatMessageMapper(
             nameText = nameText,
             message = message,
             links = findLinks(message).toImmutableList(),
+            usernameMentions = usernameMentions,
             emotes = emoteUis,
             isAction = isAction,
             thread = threadUi,

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageUiState.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/ChatMessageUiState.kt
@@ -49,6 +49,7 @@ sealed interface ChatMessageUiState {
         val nameText: String,
         val message: String,
         val links: ImmutableList<LinkUi>,
+        val usernameMentions: ImmutableList<UsernameMentionUi>,
         val emotes: ImmutableList<EmoteUi>,
         val isAction: Boolean,
         val thread: ThreadUi?,
@@ -231,6 +232,16 @@ sealed interface ChatMessageUiState {
         val replyTargetName: UserName,
     ) : ChatMessageUiState
 }
+
+@Immutable
+data class UsernameMentionUi(
+    val start: Int,
+    val end: Int,
+    val userName: UserName,
+    val displayName: DisplayName,
+    val rawColor: Int?,
+    val isBold: Boolean,
+)
 
 @Immutable
 data class BadgeUi(

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/UsernameMentions.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/UsernameMentions.kt
@@ -1,0 +1,22 @@
+package com.flxrs.dankchat.ui.chat
+
+import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.data.toUserName
+
+private val USERNAME_MENTION_REGEX = Regex("""(?<!\S)@(\w+)(?=[.,!?;:]*(?:\s|$))""")
+
+internal data class UsernameMention(
+    val start: Int,
+    val end: Int,
+    val userName: UserName,
+)
+
+internal fun findUsernameMentions(message: String): List<UsernameMention> = USERNAME_MENTION_REGEX
+    .findAll(message)
+    .map { match ->
+        UsernameMention(
+            start = match.range.first,
+            end = match.range.last + 1,
+            userName = match.groupValues[1].toUserName(),
+        )
+    }.toList()

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/PrivMessage.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/PrivMessage.kt
@@ -40,7 +40,9 @@ import com.flxrs.dankchat.data.toUserName
 import com.flxrs.dankchat.ui.chat.BadgeUi
 import com.flxrs.dankchat.ui.chat.ChatMessageUiState
 import com.flxrs.dankchat.ui.chat.emote.EmoteSheetData
+import com.flxrs.dankchat.ui.chat.messages.common.MENTIONED_USER_ANNOTATION_TAG
 import com.flxrs.dankchat.ui.chat.messages.common.MessageTextWithInlineContent
+import com.flxrs.dankchat.ui.chat.messages.common.ResolvedUsernameMention
 import com.flxrs.dankchat.ui.chat.messages.common.appendInlineSpacer
 import com.flxrs.dankchat.ui.chat.messages.common.appendWithLinks
 import com.flxrs.dankchat.ui.chat.messages.common.launchCustomTab
@@ -212,6 +214,16 @@ private fun PrivMessageText(
     val defaultTextColor = rememberAdaptiveTextColor(backgroundColor)
     val nameColor = rememberNormalizedColor(message.rawNameColor, backgroundColor)
     val linkColor = rememberAdaptiveLinkColor(backgroundColor)
+    val usernameMentions =
+        message.usernameMentions.map { mention ->
+            ResolvedUsernameMention(
+                start = mention.start,
+                end = mention.end,
+                color = mention.rawColor?.let { rememberNormalizedColor(it, backgroundColor) },
+                isBold = mention.isBold,
+                userAnnotation = "|${mention.userName.value}|${mention.displayName.value}|${message.channel.value}",
+            )
+        }
 
     // Build annotated string with text content. Keyed on the content-affecting fields only,
     // so layout-only copies (rounded corners, divider) don't rebuild the string.
@@ -223,6 +235,7 @@ private fun PrivMessageText(
             message.nameText,
             message.message,
             message.emotes,
+            usernameMentions,
             message.isAction,
             defaultTextColor,
             nameColor,
@@ -288,7 +301,13 @@ private fun PrivMessageText(
                         // Text before emote
                         if (currentPos < emote.position.first) {
                             val segment = message.message.substring(currentPos, emote.position.first)
-                            appendWithLinks(segment, currentPos, message.links, linkColor)
+                            appendWithLinks(
+                                text = segment,
+                                segmentStart = currentPos,
+                                links = message.links,
+                                linkColor = linkColor,
+                                usernameMentions = usernameMentions,
+                            )
                         }
 
                         // Emote inline content
@@ -318,7 +337,13 @@ private fun PrivMessageText(
                     // Remaining text
                     if (currentPos < message.message.length) {
                         val segment = message.message.substring(currentPos)
-                        appendWithLinks(segment, currentPos, message.links, linkColor)
+                        appendWithLinks(
+                            text = segment,
+                            segmentStart = currentPos,
+                            links = message.links,
+                            linkColor = linkColor,
+                            usernameMentions = usernameMentions,
+                        )
                     }
                 }
             }
@@ -333,23 +358,29 @@ private fun PrivMessageText(
         interactionSource = interactionSource,
         onEmoteClick = onEmoteClick,
         onTextClick = { offset ->
-            val user = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()
+            val sender = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()
+            val mentionedUser = annotatedString.getStringAnnotations(MENTIONED_USER_ANNOTATION_TAG, offset, offset).firstOrNull()
+            val user = sender ?: mentionedUser
             val url = annotatedString.getStringAnnotations("URL", offset, offset).firstOrNull()
 
             when {
                 user != null -> parseUserAnnotation(user.item)?.let {
-                    onUserClick(it.userId, it.userName, it.displayName, it.channel.orEmpty(), message.badges, false)
+                    val badges = if (sender != null) message.badges else emptyList()
+                    onUserClick(it.userId, it.userName, it.displayName, it.channel.orEmpty(), badges, false)
                 }
 
                 url != null -> launchCustomTab(context, url.item)
             }
         },
         onTextLongClick = { offset ->
-            val user = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()
+            val sender = annotatedString.getStringAnnotations("USER", offset, offset).firstOrNull()
+            val mentionedUser = annotatedString.getStringAnnotations(MENTIONED_USER_ANNOTATION_TAG, offset, offset).firstOrNull()
+            val user = sender ?: mentionedUser
 
             when {
                 user != null -> parseUserAnnotation(user.item)?.let {
-                    onUserClick(it.userId, it.userName, it.displayName, it.channel.orEmpty(), message.badges, true)
+                    val badges = if (sender != null) message.badges else emptyList()
+                    onUserClick(it.userId, it.userName, it.displayName, it.channel.orEmpty(), badges, true)
                 }
 
                 else -> onMessageLongClick(message.id, message.channel.value, message.fullMessage)

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/Linkification.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/Linkification.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import kotlinx.collections.immutable.ImmutableList
@@ -61,11 +62,42 @@ fun AnnotatedString.Builder.appendWithLinks(
     segmentStart: Int,
     links: ImmutableList<LinkUi>,
     linkColor: Color,
+) = appendWithLinks(text, segmentStart, links, linkColor, emptyList())
+
+internal fun AnnotatedString.Builder.appendWithLinks(
+    text: String,
+    segmentStart: Int,
+    links: ImmutableList<LinkUi>,
+    linkColor: Color,
+    usernameMentions: List<ResolvedUsernameMention>,
 ) {
+    val segmentEnd = segmentStart + text.length
+    val ranges =
+        buildList {
+            links.forEach { link ->
+                if (link.start >= segmentStart && link.end <= segmentEnd) {
+                    add(StyledTextRange.Link(link.start, link.end, link.url))
+                }
+            }
+            usernameMentions.forEach { mention ->
+                if (mention.start >= segmentStart && mention.end <= segmentEnd) {
+                    add(
+                        StyledTextRange.UsernameMention(
+                            mention.start,
+                            mention.end,
+                            mention.color,
+                            mention.isBold,
+                            mention.userAnnotation,
+                        ),
+                    )
+                }
+            }
+        }.sortedBy { it.start }
+
     var lastIndex = 0
-    links.forEach { link ->
-        val start = link.start - segmentStart
-        val end = link.end - segmentStart
+    ranges.forEach { range ->
+        val start = range.start - segmentStart
+        val end = range.end - segmentStart
         if (start < lastIndex || end > text.length) {
             return@forEach
         }
@@ -74,11 +106,28 @@ fun AnnotatedString.Builder.appendWithLinks(
             append(text.substring(lastIndex, start))
         }
 
-        pushStringAnnotation(tag = URL_ANNOTATION_TAG, annotation = link.url)
-        withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
-            append(text.substring(start, end))
+        when (range) {
+            is StyledTextRange.Link -> {
+                pushStringAnnotation(tag = URL_ANNOTATION_TAG, annotation = range.url)
+                withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+                    append(text.substring(start, end))
+                }
+                pop()
+            }
+
+            is StyledTextRange.UsernameMention -> {
+                pushStringAnnotation(tag = MENTIONED_USER_ANNOTATION_TAG, annotation = range.userAnnotation)
+                withStyle(
+                    SpanStyle(
+                        color = range.color ?: Color.Unspecified,
+                        fontWeight = if (range.isBold) FontWeight.Bold else null,
+                    ),
+                ) {
+                    append(text.substring(start, end))
+                }
+                pop()
+            }
         }
-        pop()
 
         lastIndex = end
     }
@@ -86,6 +135,25 @@ fun AnnotatedString.Builder.appendWithLinks(
     if (lastIndex < text.length) {
         append(text.substring(lastIndex))
     }
+}
+
+private sealed interface StyledTextRange {
+    val start: Int
+    val end: Int
+
+    data class Link(
+        override val start: Int,
+        override val end: Int,
+        val url: String,
+    ) : StyledTextRange
+
+    data class UsernameMention(
+        override val start: Int,
+        override val end: Int,
+        val color: Color?,
+        val isBold: Boolean,
+        val userAnnotation: String,
+    ) : StyledTextRange
 }
 
 fun AnnotatedString.Builder.appendWithLinks(

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/UsernameMentionStyling.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/messages/common/UsernameMentionStyling.kt
@@ -1,0 +1,13 @@
+package com.flxrs.dankchat.ui.chat.messages.common
+
+import androidx.compose.ui.graphics.Color
+
+internal data class ResolvedUsernameMention(
+    val start: Int,
+    val end: Int,
+    val color: Color?,
+    val isBold: Boolean,
+    val userAnnotation: String,
+)
+
+internal const val MENTIONED_USER_ANNOTATION_TAG = "MENTIONED_USER"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -552,6 +552,10 @@
     <string name="preference_user_long_click_summary_off">Regular click mentions, long click opens popup</string>
     <string name="preference_colorize_nicknames_title">Colorize nicknames</string>
     <string name="preference_colorize_nicknames_summary">Assign a random color to users without a set color</string>
+    <string name="preference_bold_username_mentions_title">Bold @usernames</string>
+    <string name="preference_bold_username_mentions_summary">Make @mentions more noticeable</string>
+    <string name="preference_color_username_mentions_title">Color @usernames</string>
+    <string name="preference_color_username_mentions_summary">Use a user’s Twitch color for @mentions when available</string>
     <string name="preference_tts_force_english_title">Force language to English</string>
     <string name="preference_tts_force_english_summary">Force TTS voice language to English instead of system default</string>
     <string name="preference_visible_emotes_title">Visible third party emotes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,6 +603,10 @@
     <string name="preference_user_long_click_summary_off">Regular click mentions, long click opens popup</string>
     <string name="preference_colorize_nicknames_title">Colorize nicknames</string>
     <string name="preference_colorize_nicknames_summary">Assign a random color to users without a set color</string>
+    <string name="preference_bold_username_mentions_title">Bold @usernames</string>
+    <string name="preference_bold_username_mentions_summary">Make @mentions more noticeable</string>
+    <string name="preference_color_username_mentions_title">Color @usernames</string>
+    <string name="preference_color_username_mentions_summary">Use a user’s Twitch color for @mentions when available</string>
     <string name="preference_tts_force_english_key" translatable="false">tts_force_english_key</string>
     <string name="preference_tts_force_english_title">Force language to English</string>
     <string name="preference_tts_force_english_summary">Force TTS voice language to English instead of system default</string>

--- a/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/UsernameMentionsTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/UsernameMentionsTest.kt
@@ -1,0 +1,38 @@
+package com.flxrs.dankchat.ui.chat
+
+import com.flxrs.dankchat.data.toUserName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class UsernameMentionsTest {
+    @Test
+    fun `finds usernames at word boundaries`() {
+        val mentions = findUsernameMentions("hello @forsen and @Iore")
+
+        assertEquals(
+            listOf(
+                UsernameMention(6, 13, "forsen".toUserName()),
+                UsernameMention(18, 23, "Iore".toUserName()),
+            ),
+            mentions,
+        )
+    }
+
+    @Test
+    fun `excludes trailing punctuation from username`() {
+        assertEquals(
+            listOf(UsernameMention(0, 7, "forsen".toUserName())),
+            findUsernameMentions("@forsen!!!"),
+        )
+    }
+
+    @Test
+    fun `ignores at signs inside other text`() {
+        assertEquals(emptyList(), findUsernameMentions("test@example.com and hello@forsen"))
+    }
+
+    @Test
+    fun `ignores invalid username tokens`() {
+        assertEquals(emptyList(), findUsernameMentions("@forsen-name @Iore/other"))
+    }
+}

--- a/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/messages/common/UsernameMentionStylingTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/ui/chat/messages/common/UsernameMentionStylingTest.kt
@@ -1,0 +1,56 @@
+package com.flxrs.dankchat.ui.chat.messages.common
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class UsernameMentionStylingTest {
+    @Test
+    fun `preserves links while styling usernames`() {
+        val text = "@forsen https://example.com"
+        val mentionColor = Color.Red
+        val linkColor = Color.Blue
+
+        val result =
+            buildAnnotatedString {
+                appendWithLinks(
+                    text = text,
+                    segmentStart = 0,
+                    links = persistentListOf(LinkUi(8, text.length, "https://example.com")),
+                    linkColor = linkColor,
+                    usernameMentions = listOf(ResolvedUsernameMention(0, 7, mentionColor, true, "|forsen|forsen|iore")),
+                )
+            }
+
+        assertEquals(text, result.text)
+        assertEquals(
+            mentionColor,
+            result.spanStyles
+                .single { it.start == 0 }
+                .item.color,
+        )
+        assertEquals(
+            FontWeight.Bold,
+            result.spanStyles
+                .single { it.start == 0 }
+                .item.fontWeight,
+        )
+        assertEquals(
+            linkColor,
+            result.spanStyles
+                .single { it.start == 8 }
+                .item.color,
+        )
+        assertEquals(
+            "|forsen|forsen|iore",
+            result.getStringAnnotations(MENTIONED_USER_ANNOTATION_TAG, 0, 0).single().item,
+        )
+        assertEquals(
+            "https://example.com",
+            result.getStringAnnotations(URL_ANNOTATION_TAG, 8, 8).single().item,
+        )
+    }
+}


### PR DESCRIPTION
Adds options to bold and colour `@mentions` in chat. Both default to on.

If DankChat has seen a user's Twitch colour, it is used for their `@username`. Otherwise, the normal message text colour is used.

Tapping or long-pressing one has the same behaviour as interacting with a message sender's username.

https://github.com/user-attachments/assets/e246ca47-e4cc-454e-b864-decab45a7d7c

