### PR TITLE
feat: ignore highlights from user card

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/database/dao/BlacklistedUserDao.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/database/dao/BlacklistedUserDao.kt
@@ -15,6 +15,9 @@ interface BlacklistedUserDao {
     @Query("SELECT * FROM blacklisted_user_highlight")
     fun getBlacklistedUserFlow(): Flow<List<BlacklistedUserEntity>>
 
+    @Query("SELECT * FROM blacklisted_user_highlight WHERE is_regex = 0 AND username COLLATE NOCASE = :username")
+    suspend fun getExactBlacklistedUsers(username: String): List<BlacklistedUserEntity>
+
     @Upsert
     suspend fun addBlacklistedUser(user: BlacklistedUserEntity): Long
 
@@ -23,6 +26,9 @@ interface BlacklistedUserDao {
 
     @Delete
     suspend fun deleteBlacklistedUser(user: BlacklistedUserEntity)
+
+    @Query("DELETE FROM blacklisted_user_highlight WHERE is_regex = 0 AND username COLLATE NOCASE = :username")
+    suspend fun deleteExactBlacklistedUsers(username: String)
 
     @Query("DELETE FROM blacklisted_user_highlight")
     suspend fun deleteAllBlacklistedUsers()

--- a/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepository.kt
@@ -228,6 +228,33 @@ class HighlightsRepository(
         blacklistedUserDao.addBlacklistedUsers(entities)
     }
 
+    fun isUserHighlightsIgnored(name: UserName): Boolean = blacklistedUsers.value.any { !it.isRegex && it.enabled && name.value.equals(it.username, ignoreCase = true) }
+
+    suspend fun setUserHighlightsIgnored(
+        name: UserName,
+        ignored: Boolean,
+    ) {
+        if (!ignored) {
+            blacklistedUserDao.deleteExactBlacklistedUsers(name.value)
+            return
+        }
+
+        val existing = blacklistedUserDao.getExactBlacklistedUsers(name.value)
+        when {
+            existing.isEmpty() -> {
+                blacklistedUserDao.addBlacklistedUser(
+                    BlacklistedUserEntity(
+                        id = 0,
+                        enabled = true,
+                        username = name.value,
+                    ),
+                )
+            }
+
+            existing.any { !it.enabled } -> blacklistedUserDao.addBlacklistedUsers(existing.map { it.copy(enabled = true) })
+        }
+    }
+
     private fun UserNoticeMessage.calculateHighlightState(): UserNoticeMessage {
         val messageHighlights = validMessageHighlights.value
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/user/UserPopupDialog.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/user/UserPopupDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Report
 import androidx.compose.material3.Button
@@ -36,6 +37,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
@@ -71,6 +73,8 @@ fun UserPopupDialog(
     badges: ImmutableList<BadgeUi>,
     onBlockUser: () -> Unit,
     onUnblockUser: () -> Unit,
+    ignoresHighlights: Boolean,
+    onIgnoreHighlightsChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     onOpenChannel: (String) -> Unit,
     onReport: (String) -> Unit,
@@ -221,6 +225,21 @@ fun UserPopupDialog(
                                         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                                     ) {
                                         Text(if (isBlocked) stringResource(R.string.user_popup_unblock) else stringResource(R.string.user_popup_block))
+                                    }
+                                }
+                                if (!isOwnUser) {
+                                    ListItem(
+                                        leadingContent = { Icon(Icons.Default.NotificationsOff, contentDescription = null) },
+                                        trailingContent = {
+                                            Switch(
+                                                checked = ignoresHighlights,
+                                                onCheckedChange = onIgnoreHighlightsChange,
+                                            )
+                                        },
+                                        modifier = Modifier.clickable { onIgnoreHighlightsChange(!ignoresHighlights) },
+                                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                    ) {
+                                        Text(stringResource(R.string.user_popup_ignore_highlights))
                                     }
                                 }
                                 if (!isOwnUser) {

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/user/UserPopupViewModel.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/chat/user/UserPopupViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.flxrs.dankchat.data.UserId
 import com.flxrs.dankchat.data.UserName
+import com.flxrs.dankchat.data.repo.HighlightsRepository
 import com.flxrs.dankchat.data.repo.IgnoresRepository
 import com.flxrs.dankchat.data.repo.channel.ChannelRepository
 import com.flxrs.dankchat.data.repo.chat.UserStateRepository
@@ -24,12 +25,14 @@ data class UserPopupUiState(
     val channel: UserName?,
     val badges: List<Badge>,
     val isOwnUser: Boolean,
+    val ignoresHighlights: Boolean,
 )
 
 @KoinViewModel
 class UserPopupViewModel(
     private val channelRepository: ChannelRepository,
     private val dataRepository: DataRepository,
+    private val highlightsRepository: HighlightsRepository,
     private val ignoresRepository: IgnoresRepository,
     private val userStateRepository: UserStateRepository,
     private val preferenceStore: DankChatPreferenceStore,
@@ -60,6 +63,17 @@ class UserPopupViewModel(
         ignoresRepository.removeUserBlock(targetUserId, targetUsername)
     }
 
+    fun setIgnoreHighlights(ignored: Boolean) {
+        val params = currentParams ?: return
+        viewModelScope.launch {
+            runCatching {
+                highlightsRepository.setUserHighlightsIgnored(params.targetUserName, ignored)
+            }.onSuccess {
+                _state.value = _state.value?.copy(ignoresHighlights = ignored)
+            }
+        }
+    }
+
     private fun emitState(
         params: UserPopupStateParams,
         popupState: UserPopupState,
@@ -69,6 +83,7 @@ class UserPopupViewModel(
             channel = params.channel,
             badges = params.badges,
             isOwnUser = params.targetUserId != null && preferenceStore.userIdString == params.targetUserId,
+            ignoresHighlights = highlightsRepository.isUserHighlightsIgnored(params.targetUserName),
         )
     }
 

--- a/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/UserPopupSheetContainer.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/ui/main/dialog/UserPopupSheetContainer.kt
@@ -33,6 +33,8 @@ fun UserPopupSheetContainer(onOpenUrl: (String) -> Unit) {
         state = currentState.popupState,
         badges = badges,
         isOwnUser = currentState.isOwnUser,
+        ignoresHighlights = currentState.ignoresHighlights,
+        onIgnoreHighlightsChange = userPopupViewModel::setIgnoreHighlights,
         onBlockUser = userPopupViewModel::blockUser,
         onUnblockUser = userPopupViewModel::unblockUser,
         onDismiss = userPopupViewModel::dismiss,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,6 +284,7 @@
     <string name="user_popup_unblock">Unblock</string>
     <string name="user_popup_mention">Mention user</string>
     <string name="user_popup_whisper">Whisper user</string>
+    <string name="user_popup_ignore_highlights">Ignore highlights</string>
     <string name="user_popup_created">Created: %1$s</string>
     <string name="user_popup_following_since">Following since %1$s</string>
     <string name="user_popup_not_following">Not following</string>

--- a/app/src/test/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/data/repo/HighlightsRepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.flxrs.dankchat.data.repo
 
+import com.flxrs.dankchat.data.UserName
 import com.flxrs.dankchat.data.database.dao.BadgeHighlightDao
 import com.flxrs.dankchat.data.database.dao.BlacklistedUserDao
 import com.flxrs.dankchat.data.database.dao.MessageHighlightDao
 import com.flxrs.dankchat.data.database.dao.UserHighlightDao
 import com.flxrs.dankchat.data.database.entity.BadgeHighlightEntity
+import com.flxrs.dankchat.data.database.entity.BlacklistedUserEntity
 import com.flxrs.dankchat.data.database.entity.MessageHighlightEntity
 import com.flxrs.dankchat.data.database.entity.MessageHighlightEntityType
 import com.flxrs.dankchat.di.DispatchersProvider
@@ -17,12 +19,14 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -37,6 +41,31 @@ internal class HighlightsRepositoryTest {
         }
 
     private val messageHighlightDao = FakeMessageHighlightDao()
+    private val blacklistedUsers = MutableStateFlow<List<BlacklistedUserEntity>>(emptyList())
+    private val blacklistedUserDao =
+        mockk<BlacklistedUserDao> {
+            every { getBlacklistedUserFlow() } returns blacklistedUsers
+            coEvery { getExactBlacklistedUsers(any()) } answers {
+                val username = firstArg<String>()
+                blacklistedUsers.value.filter { !it.isRegex && it.username.equals(username, ignoreCase = true) }
+            }
+            coEvery { addBlacklistedUser(any()) } answers {
+                val user = firstArg<BlacklistedUserEntity>()
+                val id = user.id.takeIf { it != 0L } ?: ((blacklistedUsers.value.maxOfOrNull { it.id } ?: 0L) + 1L)
+                blacklistedUsers.value = blacklistedUsers.value.filterNot { it.id == id } + user.copy(id = id)
+                id
+            }
+            coEvery { addBlacklistedUsers(any()) } answers {
+                firstArg<List<BlacklistedUserEntity>>().forEach { user ->
+                    val id = user.id.takeIf { it != 0L } ?: ((blacklistedUsers.value.maxOfOrNull { it.id } ?: 0L) + 1L)
+                    blacklistedUsers.value = blacklistedUsers.value.filterNot { it.id == id } + user.copy(id = id)
+                }
+            }
+            coEvery { deleteExactBlacklistedUsers(any()) } answers {
+                val username = firstArg<String>()
+                blacklistedUsers.value = blacklistedUsers.value.filterNot { !it.isRegex && it.username.equals(username, ignoreCase = true) }
+            }
+        }
     private val badgeHighlightDao =
         mockk<BadgeHighlightDao> {
             every { getBadgeHighlightsFlow() } returns flowOf(emptyList())
@@ -47,7 +76,7 @@ internal class HighlightsRepositoryTest {
         messageHighlightDao = messageHighlightDao,
         userHighlightDao = mockk<UserHighlightDao> { every { getUserHighlightsFlow() } returns flowOf(emptyList()) },
         badgeHighlightDao = badgeHighlightDao,
-        blacklistedUserDao = mockk<BlacklistedUserDao> { every { getBlacklistedUserFlow() } returns flowOf(emptyList()) },
+        blacklistedUserDao = blacklistedUserDao,
         preferences = mockk<DankChatPreferenceStore> { every { currentUserAndDisplayFlow } returns emptyFlow() },
         notificationsSettingsDataStore = mockk<NotificationsSettingsDataStore>(),
         dispatchersProvider = dispatchersProvider,
@@ -128,6 +157,57 @@ internal class HighlightsRepositoryTest {
         createRepository().runMigrationsIfNeeded().join()
 
         coVerify(exactly = 0) { badgeHighlightDao.addHighlights(any()) }
+    }
+
+    @Test
+    fun `ignoring highlights enables all case insensitive exact entries`() = runTest(testDispatcher) {
+        blacklistedUsers.value =
+            listOf(
+                BlacklistedUserEntity(id = 1, enabled = true, username = "for.*", isRegex = true),
+                BlacklistedUserEntity(id = 2, enabled = false, username = "forsen"),
+                BlacklistedUserEntity(id = 3, enabled = false, username = "FORSEN"),
+            )
+        val repository = createRepository()
+
+        assertFalse(repository.isUserHighlightsIgnored(UserName("forsen")))
+
+        repository.setUserHighlightsIgnored(UserName("forsen"), true)
+
+        assertTrue(repository.isUserHighlightsIgnored(UserName("forsen")))
+        assertEquals(3, blacklistedUsers.value.size)
+        assertTrue(blacklistedUsers.value.filterNot { it.isRegex }.all { it.enabled })
+    }
+
+    @Test
+    fun `ignoring highlights adds an exact entry when none exists`() = runTest(testDispatcher) {
+        val regex = BlacklistedUserEntity(id = 1, enabled = true, username = "for.*", isRegex = true)
+        blacklistedUsers.value = listOf(regex)
+        val repository = createRepository()
+
+        repository.setUserHighlightsIgnored(UserName("forsen"), true)
+
+        assertEquals(
+            listOf(regex, BlacklistedUserEntity(id = 2, enabled = true, username = "forsen")),
+            blacklistedUsers.value,
+        )
+    }
+
+    @Test
+    fun `allowing highlights removes only exact entries for that user`() = runTest(testDispatcher) {
+        val regex = BlacklistedUserEntity(id = 1, enabled = true, username = "for.*", isRegex = true)
+        val otherUser = BlacklistedUserEntity(id = 2, enabled = true, username = "Iore")
+        blacklistedUsers.value =
+            listOf(
+                regex,
+                otherUser,
+                BlacklistedUserEntity(id = 3, enabled = true, username = "forsen"),
+                BlacklistedUserEntity(id = 4, enabled = false, username = "FORSEN"),
+            )
+        val repository = createRepository()
+
+        repository.setUserHighlightsIgnored(UserName("Forsen"), false)
+
+        assertEquals(listOf(regex, otherUser), blacklistedUsers.value)
     }
 }
 


### PR DESCRIPTION
Adds an "Ignore highlights" toggle to user cards, which controls corresponding entries under "Blacklisted Users" menu (regex entries ignored).