### PR TITLE
feat: show human-readable timeout durations

### DIFF
--- a/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/ModerationMessage.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/data/twitch/message/ModerationMessage.kt
@@ -406,12 +406,9 @@ data class ModerationMessage(
         private fun joinDurationParts(
             parts: List<TextResource>,
             fallback: () -> TextResource,
-        ): TextResource = when (parts.size) {
-            0 -> fallback()
-            1 -> parts[0]
-            2 -> TextResource.Res(R.string.duration_join_2, persistentListOf(parts[0], parts[1]))
-            else -> TextResource.Res(R.string.duration_join_3, persistentListOf(parts[0], parts[1], parts[2]))
-        }
+        ): TextResource = parts.reduceOrNull { joined, part ->
+            TextResource.Res(R.string.duration_join_2, persistentListOf(joined, part))
+        } ?: fallback()
 
         fun parseClearChat(message: IrcMessage): ModerationMessage = with(message) {
             val channel = params[0].substring(1)

--- a/app/src/main/kotlin/com/flxrs/dankchat/utils/DateTimeUtils.kt
+++ b/app/src/main/kotlin/com/flxrs/dankchat/utils/DateTimeUtils.kt
@@ -98,10 +98,17 @@ object DateTimeUtils {
     }
 
     fun decomposeSeconds(totalSeconds: Int): List<DurationPart> = buildList {
-        val mins = totalSeconds / 60
-        val secs = totalSeconds % 60
-        if (mins > 0) add(DurationPart(mins, DurationUnit.MINUTES))
-        if (secs > 0) add(DurationPart(secs, DurationUnit.SECONDS))
+        var remaining = totalSeconds
+        val days = remaining / 86400
+        remaining %= 86400
+        if (days > 0) add(DurationPart(days, DurationUnit.DAYS))
+        val hours = remaining / 3600
+        remaining %= 3600
+        if (hours > 0) add(DurationPart(hours, DurationUnit.HOURS))
+        val minutes = remaining / 60
+        remaining %= 60
+        if (minutes > 0) add(DurationPart(minutes, DurationUnit.MINUTES))
+        if (remaining > 0) add(DurationPart(remaining, DurationUnit.SECONDS))
     }
 
     fun calculateUptime(startedAtString: String): String {

--- a/app/src/test/kotlin/com/flxrs/dankchat/utils/DateTimeUtilsTest.kt
+++ b/app/src/test/kotlin/com/flxrs/dankchat/utils/DateTimeUtilsTest.kt
@@ -174,6 +174,21 @@ internal class DateTimeUtilsTest {
     }
 
     @Test
+    fun `decomposes 36000 seconds to 10 hours`() {
+        val result = DateTimeUtils.decomposeSeconds(36000)
+        assertEquals(expected = listOf(DurationPart(10, HOURS)), actual = result)
+    }
+
+    @Test
+    fun `decomposes seconds to days hours minutes and seconds`() {
+        val result = DateTimeUtils.decomposeSeconds(90061)
+        assertEquals(
+            expected = listOf(DurationPart(1, DAYS), DurationPart(1, HOURS), DurationPart(1, MINUTES), DurationPart(1, SECONDS)),
+            actual = result,
+        )
+    }
+
+    @Test
     fun `decomposes 0 seconds to empty list`() {
         val result = DateTimeUtils.decomposeSeconds(0)
         assertEquals(expected = emptyList(), actual = result)


### PR DESCRIPTION
Makes timeout durations human-readable, e.g. what is currently `720 minutes` will become `12 hours`.